### PR TITLE
Add a wrapper for decl traversal

### DIFF
--- a/src/clang/api/AST/DeclBase.jl
+++ b/src/clang/api/AST/DeclBase.jl
@@ -195,6 +195,16 @@ function PrintStats(x::AbstractDecl)
 end
 
 # Decl Cast
+function castToDeclContext(x::AbstractDecl)
+    @check_ptrs x
+    return DeclContext(clang_Decl_castToDeclContext(x))
+end
+
+function castFromDeclContext(x::DeclContext)
+    @check_ptrs x
+    return Decl(clang_Decl_castFromDeclContext(x))
+end
+
 function ClassTemplateDecl(x::AbstractDecl)
     @check_ptrs x
     return ClassTemplateDecl(clang_Decl_castToClassTemplateDecl(x))
@@ -339,6 +349,11 @@ end
 function dumpLookups(x::DeclContext)
     @check_ptrs x
     return clang_DeclContext_dumpLookups(x)
+end
+
+function decl_iterator_begin(x::DeclContext)
+    @check_ptrs x
+    return Decl(clang_DeclContext_decl_iterator_begin(x))
 end
 
 # DeclContext Cast

--- a/src/clang/ast.jl
+++ b/src/clang/ast.jl
@@ -35,3 +35,20 @@ Base.isempty(x::DeclarationName) = isEmpty(x)
 Base.string(x::DeclarationName) = get_as_string(x)
 
 dump(x::CXXScopeSpec) = dump(getScopeRep(x))
+
+# DeclContext
+"""
+    struct DeclIterator <: Any
+An iterator for traversing the declarations in a `DeclContext`.
+See also `clang::DeclContext::decl_iterator`.
+"""
+struct DeclIterator{T<:AbstractDecl}
+    decl::T
+end
+
+function Base.iterate(x::DeclIterator, state=decl_iterator_begin(castToDeclContext(x.decl)))
+    state.ptr == C_NULL && return nothing
+    next_decl = getNextDeclInContext(state)
+    next_decl.ptr == C_NULL && return nothing
+    return (next_decl, next_decl)
+end

--- a/test/code/main.cpp
+++ b/test/code/main.cpp
@@ -1,7 +1,12 @@
 #include <iostream>
 #include <vector>
 
-int main() {   
+struct Node {
+    int x;
+    float y;
+};
+
+int main() {
   int x = 40;
   int y = 2;
   int z = x + y;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ include("clang/source.jl")
 include("clang/instance.jl")
 
 include("lookup.jl")
+include("traversal.jl")
 if Sys.isapple()
     include("call.jl")
     include("execution.jl")

--- a/test/traversal.jl
+++ b/test/traversal.jl
@@ -1,0 +1,18 @@
+using ClangCompiler
+using Test
+import ClangCompiler as cc
+
+@testset "Traversal | AST" begin
+    src = joinpath(@__DIR__, "code", "main.cpp")
+    args = get_compiler_args()
+    irgen = ClangCompiler.IncrementalIRGenerator(src, args)
+    decl_lookup = DeclFinder(get_instance(irgen))
+    @test decl_lookup(irgen, "Node", "Node")
+    decl = get_decl(decl_lookup)
+    for field in cc.DeclIterator(decl)
+        cc.dump(field)
+        @test cc.getDeclKindName(field) == "Field"
+    end
+    dispose(decl_lookup)
+    dispose(irgen)
+end


### PR DESCRIPTION
I was thinking about reimplementing `decl_iterator` class in Julia. Unfortunately, it calls `LoadLexicalDeclsFromExternalStorage` which is a private API of Clang, so it's inevitable to add a thin wrapper for `decls_begin`.

`specific_decl_iterator` is essentially a wrapper of `decl_iterator` and we could reimplement it in Julia. 