### PR TITLE
fix `hack` path

### DIFF
--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -32,11 +32,11 @@ function IRGenerator(src::String, args::Vector{String}; diag_show_colors=true)
     # invocation
     if Sys.isapple()
         # FIXME: Duplicate definition of symbol '___cxa_atexit'
-        # icxxabi_inc = joinpath(@__DIR__, "..", "abi") |> normpath
+        # icxxabi_inc = joinpath(@__DIR__, "..", "..", "abi") |> normpath
         # insert!(args, length(args), "-isystem$icxxabi_inc")
         # insert!(args, length(args), "-includeicxxabi.h")
     elseif Sys.islinux()
-        hack_inc = joinpath(@__DIR__, "..", "hack") |> normpath
+        hack_inc = joinpath(@__DIR__, "..", "..", "hack") |> normpath
         insert!(args, length(args), "-isystem$hack_inc")
         insert!(args, length(args), "-include"*"hack_linux.h")
     end


### PR DESCRIPTION
For https://github.com/Gnimuc/ClangCompiler.jl#jit-experimental (which despite this fix segfaults on `linux`, investigating it ...)