### PR TITLE
Add comprehensive C API wrappers for Clang expression and operator types

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,176 @@
+# ClangCompiler.jl — Project Summary
+
+## Overview
+
+**ClangCompiler.jl** is a Julia package that provides a high-level interface to the Clang C++ compiler infrastructure. It wraps the libclangex C API (from `libclangex_jll`) to expose Clang's internal compiler capabilities directly to Julia, enabling tasks such as:
+
+- C/C++ declaration lookup and name resolution
+- AST (Abstract Syntax Tree) traversal and introspection
+- Incremental C++ parsing and compilation
+- JIT execution of compiled C++ code from Julia
+- Type system bridging between Julia and Clang/LLVM types
+
+## Architecture
+
+```
+ClangCompiler.jl
+├── lib/                     # Auto-generated C API bindings
+│   ├── LibClang.jl          # Standard libclang bindings
+│   └── 18/LibClangEx.jl     # libclangex bindings (1,655 functions)
+├── src/
+│   ├── ClangCompiler.jl     # Main module
+│   ├── clang/               # Low-level Clang API wrappers
+│   │   ├── core/            # Core type definitions and wrappers
+│   │   ├── api/             # Julia API layer over C bindings
+│   │   ├── ast.jl           # AST node types and iteration
+│   │   ├── basic.jl         # Source locations, diagnostics
+│   │   ├── codegen.jl       # Code generation module access
+│   │   ├── frontend.jl      # Compiler instance/frontend
+│   │   ├── lex.jl           # Lexer and token types
+│   │   ├── parse.jl         # Parser interface
+│   │   ├── qualtype.jl      # Qualified type operations
+│   │   ├── sema.jl          # Semantic analysis
+│   │   └── type.jl          # Type system wrappers
+│   ├── compiler/
+│   │   ├── compiler.jl      # AbstractClangCompiler base type
+│   │   └── interpreter.jl   # CxxInterpreter implementation
+│   ├── types.jl             # Julia<->Clang<->LLVM type mappings
+│   ├── lookup.jl            # Declaration lookup (DeclFinder)
+│   ├── parse.jl             # C++ scope specifier parsing
+│   ├── env.jl               # Compiler flags and default args
+│   └── platform/JLLEnvs.jl  # Platform-specific JLL environments
+├── deps/ClangExtra/         # libclangex C header files (58 headers)
+└── gen/generator.jl         # Auto-generator for C API bindings
+```
+
+## Key Components
+
+### CxxInterpreter
+
+The primary entry point. Wraps Clang's `IncrementalCompiler` to provide an incremental C++ interpreter:
+
+```julia
+import ClangCompiler as CC
+
+I = CC.create_interpreter(["-include", "vector"])
+CC.compile(I, "int square(int x) { return x * x; }")
+p = CC.get_function_pointer(I, "square")
+@ccall $p(5::Cint)::Cint  # => 25
+CC.dispose(I)
+```
+
+**Public API:**
+- `create_interpreter(args; is_cxx, version)` — create a C/C++ interpreter
+- `dispose(interp)` — release resources
+- `parse(interp, code)` — parse a code fragment into a `PartialTranslationUnit`
+- `execute(interp, tu)` — JIT-compile and execute a parsed unit
+- `compile(interp, code)` — parse + execute in one step
+- `get_function_pointer(interp, name)` — get a pointer to a compiled symbol
+- `get_instance(interp)` — access the underlying `CompilerInstance`
+- `get_ast_context(interp)` — access the `ASTContext`
+- `get_parser(interp)`, `get_sema(interp)` — access Parser/Sema
+
+### DeclFinder
+
+A functor for performing C++ declaration lookups by name:
+
+```julia
+decl_lookup = CC.DeclFinder(I)
+@assert decl_lookup(I, "std::vector")
+decl = CC.get_decl(decl_lookup)
+CC.dump(decl)
+CC.dispose(decl_lookup)
+```
+
+**Public API:**
+- `DeclFinder(interp)` — create a lookup instance
+- `reset(finder)` — clear lookup state
+- `get_decl(finder)` — retrieve the unique lookup result
+- `get_decls(finder)` — retrieve all lookup results
+
+### AST Traversal
+
+`DeclIterator` provides iteration over child declarations:
+
+```julia
+record = CC.getTemplatedDecl(CC.ClassTemplateDecl(decl.ptr))
+for child in CC.DeclIterator(record)
+    CC.dump(child)
+end
+```
+
+### Type System Bridging
+
+`jlty_to_clty` and `clty_to_jlty` map between Julia types and Clang's type system. `clty_to_llvmty_mem` converts Clang types to their LLVM memory representation for code generation.
+
+**Supported Julia↔Clang type mappings:**
+
+| Julia Type | Clang Type |
+|---|---|
+| `Nothing` | `void` |
+| `Bool` | `bool` |
+| `Int8/UInt8` | `signed char / unsigned char` |
+| `Int16/UInt16` | `short / unsigned short` |
+| `Int32/UInt32` | `int / unsigned int` |
+| `Int64/UInt64` | `long long / unsigned long long` |
+| `Int128/UInt128` | `__int128` |
+| `Float16` | `_Float16` |
+| `Float32` | `float` |
+| `Float64` | `double` |
+| `Ptr{Cvoid}` | `void*` |
+
+## C API Coverage (libclangex)
+
+The bindings in `lib/18/LibClangEx.jl` wrap **1,655 functions** across 58 header files organized into 9 subsystems:
+
+| Subsystem | Headers | Key Functionality |
+|---|---|---|
+| **AST** | 15 | ASTContext, Decl types, Types, Expressions, Templates, Mangling |
+| **Basic** | 19 | Diagnostics, Source locations, File manager, Target info, Lang options |
+| **CodeGen** | 3 | Code generation types, Module builder, Actions |
+| **Driver** | 1 | Compiler driver |
+| **Frontend** | 4 | CompilerInstance, CompilerInvocation, Frontend options, Diagnostics |
+| **Interpreter** | 2 | Incremental interpreter, runtime values |
+| **Lex** | 4 | Lexer, Preprocessor, Tokens, Header search |
+| **Parse** | 5 | Parser, DeclSpec, Lookup, Scope, Sema |
+| **Sema** | — | Semantic analysis |
+
+### Top Function Categories
+
+| Prefix | Count | Description |
+|---|---|---|
+| `clang_ASTContext` | 232 | AST context queries |
+| `clang_FunctionDecl` | 121 | Function declarations |
+| `clang_Type` | 120 | Type system operations |
+| `clang_VarDecl` | 74 | Variable declarations |
+| `clang_isa` | 50 | RTTI type predicates |
+| `clang_CompilerInstance` | 46 | Compiler instance management |
+| `clang_Decl` | 44 | Base declaration operations |
+| `clang_value` | 42 | Runtime value operations |
+| `clang_RecordDecl` | 41 | Struct/class/union declarations |
+| `clang_TagDecl` | 35 | Tag declarations |
+
+## Dependencies
+
+| Package | Role |
+|---|---|
+| `libclangex_jll` | Native libclangex shared library |
+| `Clang_jll` | Native libclang shared library |
+| `LLVM.jl` | LLVM IR types and JIT interop |
+| `Preferences.jl` | User-configurable library path override |
+
+## Examples
+
+The `examples/` directory contains several runnable examples:
+
+- **`decl-lookup/`** — Declaration lookup workflows
+- **`clang-interpreter/`** — Incremental compilation and execution
+- **`julia-embedding/`** — Embedding Julia arrays in C++ code
+- **`LLJIT/`** — Direct LLVM JIT usage
+- **`simple-compiler/`** — Minimal compilation example
+- **`basic.jl`** — Basic API walkthrough
+- **`template-helper/`** — C++ template introspection
+
+## Binding Generation
+
+Bindings are auto-generated from the C headers in `deps/ClangExtra/include/clang-ex/` using `gen/generator.jl`, which leverages `Clang.Generators` (part of the `Clang.jl` ecosystem). The generator produces the `lib/18/LibClangEx.jl` file with all `@ccall` declarations.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -39,9 +39,37 @@ ClangCompiler.jl
 │   ├── parse.jl             # C++ scope specifier parsing
 │   ├── env.jl               # Compiler flags and default args
 │   └── platform/JLLEnvs.jl  # Platform-specific JLL environments
-├── deps/ClangExtra/         # libclangex C header files (58 headers)
+├── deps/
+│   ├── ClangExtra/          # libclangex C library source (subproject)
+│   │   ├── CMakeLists.txt   # Builds the clangex shared library
+│   │   ├── include/clang-ex/ # Public C API headers (58 headers)
+│   │   ├── lib/             # C++ wrapper implementations
+│   │   │   ├── AST/         # CXASTContext.cpp, CXDecl.cpp, ...
+│   │   │   ├── Basic/       # CXDiagnostic.cpp, CXSourceManager.cpp, ...
+│   │   │   ├── CodeGen/     # CXCodeGenAction.cpp, CXModuleBuilder.cpp, ...
+│   │   │   ├── Driver/, Frontend/, Interpreter/, Lex/, Parse/, Sema/
+│   │   │   └── libclangex.cpp / utils.cpp
+│   │   └── upstream/        # Upstream Clang headers used internally
+│   │       └── Interpreter/ # IncrementalParser.h, Interpreter.h
+│   ├── build_local.jl       # Build ClangExtra locally (CMake + Julia Scratch)
+│   └── build_ci.jl          # CI build script
 └── gen/generator.jl         # Auto-generator for C API bindings
 ```
+
+## libclangex Subproject (`deps/ClangExtra`)
+
+`deps/ClangExtra` is a self-contained C++ library that acts as a thin C wrapper around Clang's internal C++ APIs. Because Clang exposes no stable C ABI for its internal compiler infrastructure, libclangex bridges that gap by providing:
+
+1. **A stable C API** — all functions follow a `clang_<Component>_<method>` naming convention and use only C-compatible types (`void*` handles, enums, primitives), making them callable from Julia via `@ccall`.
+2. **Opaque pointer handles** — Clang C++ objects are exposed as `CX<Type>` opaque pointer typedefs (e.g. `CXASTContext`, `CXFunctionDecl`), hiding C++ ABI details.
+3. **Coverage of Clang internals** — unlike the standard `libclang`, this library exposes deep internals: `ASTContext`, `Sema`, `Parser`, `CompilerInstance`, the incremental interpreter, and more.
+
+### Build System
+
+The library is built with CMake, links against a full LLVM+Clang install, and produces a single `libclangex.{so,dylib,dll}`. Two build paths are supported:
+
+- **`libclangex_jll`** (default) — a pre-built binary artifact distributed via Julia's BinaryBuilder ecosystem. ClangCompiler.jl uses this by default.
+- **Local build** (`deps/build_local.jl`) — downloads the matching `LLVM_full_jll`, runs CMake via `CMake_jll`, installs into a Julia `Scratch` directory, and writes the resulting library path to `LocalPreferences.toml` so ClangCompiler.jl picks it up automatically. Useful when developing or patching libclangex itself.
 
 ## Key Components
 
@@ -174,3 +202,15 @@ The `examples/` directory contains several runnable examples:
 ## Binding Generation
 
 Bindings are auto-generated from the C headers in `deps/ClangExtra/include/clang-ex/` using `gen/generator.jl`, which leverages `Clang.Generators` (part of the `Clang.jl` ecosystem). The generator produces the `lib/18/LibClangEx.jl` file with all `@ccall` declarations.
+
+The full pipeline from source to Julia call is:
+
+```
+deps/ClangExtra/lib/**/*.cpp   ←  C++ wrappers around Clang internals
+        ↓  (CMake build)
+    libclangex.so              ←  shared library (shipped as libclangex_jll)
+        ↓  (gen/generator.jl)
+lib/18/LibClangEx.jl           ←  auto-generated @ccall bindings
+        ↓  (src/clang/**)
+ClangCompiler.jl public API    ←  Julia-idiomatic wrappers
+```

--- a/deps/ClangExtra/include/clang-ex/AST/CXExpr.h
+++ b/deps/ClangExtra/include/clang-ex/AST/CXExpr.h
@@ -10,37 +10,171 @@
 
 LLVM_CLANG_C_EXTERN_C_BEGIN
 
+// Expr (base)
+CXQualType clang_Expr_getType(CXExpr E);
+CXExprValueKind clang_Expr_getValueKind(CXExpr E);
+bool clang_Expr_isLValue(CXExpr E);
+bool clang_Expr_isPRValue(CXExpr E);
+bool clang_Expr_isXValue(CXExpr E);
+bool clang_Expr_isGLValue(CXExpr E);
+bool clang_Expr_isIntegerConstantExpr(CXExpr E, CXASTContext Ctx);
+bool clang_Expr_isEvaluatable(CXExpr E, CXASTContext Ctx);
+CXSourceLocation_ clang_Expr_getExprLoc(CXExpr E);
+CXSourceLocation_ clang_Expr_getBeginLoc(CXExpr E);
+CXSourceLocation_ clang_Expr_getEndLoc(CXExpr E);
+CXExpr clang_Expr_IgnoreParens(CXExpr E);
+CXExpr clang_Expr_IgnoreImpCasts(CXExpr E);
+CXExpr clang_Expr_IgnoreParenImpCasts(CXExpr E);
+CXExpr clang_Expr_IgnoreCasts(CXExpr E);
+
+// DeclRefExpr
+CXDeclRefExpr clang_DeclRefExpr_Create(CXASTContext Ctx, CXValueDecl D,
+                                       CXQualType T, CXExprValueKind VK,
+                                       CXSourceLocation_ L);
+CXValueDecl clang_DeclRefExpr_getDecl(CXDeclRefExpr E);
+CXSourceLocation_ clang_DeclRefExpr_getLocation(CXDeclRefExpr E);
+CXSourceLocation_ clang_DeclRefExpr_getBeginLoc(CXDeclRefExpr E);
+CXSourceLocation_ clang_DeclRefExpr_getEndLoc(CXDeclRefExpr E);
+
 // IntegerLiteral
 CXIntegerLiteral clang_IntegerLiteral_Create(CXASTContext C, LLVMGenericValueRef Val,
                                              CXQualType T, CXSourceLocation_ L);
-
 CXSourceLocation_ clang_IntegerLiteral_getBeginLoc(CXIntegerLiteral IL);
-
 CXSourceLocation_ clang_IntegerLiteral_getEndLoc(CXIntegerLiteral IL);
-
 CXSourceLocation_ clang_IntegerLiteral_getLocation(CXIntegerLiteral IL);
-
 void clang_IntegerLiteral_setLocation(CXIntegerLiteral IL, CXSourceLocation_ L);
+
+// FloatingLiteral
+CXFloatingLiteral clang_FloatingLiteral_Create(CXASTContext C, LLVMGenericValueRef Val,
+                                               bool IsExact, CXQualType T,
+                                               CXSourceLocation_ L);
+double clang_FloatingLiteral_getValueAsApproximateDouble(CXFloatingLiteral FL);
+CXSourceLocation_ clang_FloatingLiteral_getLocation(CXFloatingLiteral FL);
+void clang_FloatingLiteral_setLocation(CXFloatingLiteral FL, CXSourceLocation_ L);
+CXSourceLocation_ clang_FloatingLiteral_getBeginLoc(CXFloatingLiteral FL);
+CXSourceLocation_ clang_FloatingLiteral_getEndLoc(CXFloatingLiteral FL);
+
+// CharacterLiteral
+CXCharacterLiteral clang_CharacterLiteral_Create(CXASTContext C, unsigned Val,
+                                                 CXQualType T, CXSourceLocation_ L);
+unsigned clang_CharacterLiteral_getValue(CXCharacterLiteral CL);
+CXSourceLocation_ clang_CharacterLiteral_getLocation(CXCharacterLiteral CL);
+void clang_CharacterLiteral_setLocation(CXCharacterLiteral CL, CXSourceLocation_ L);
+CXSourceLocation_ clang_CharacterLiteral_getBeginLoc(CXCharacterLiteral CL);
+CXSourceLocation_ clang_CharacterLiteral_getEndLoc(CXCharacterLiteral CL);
+
+// StringLiteral
+CXSourceLocation_ clang_StringLiteral_getBeginLoc(CXStringLiteral SL);
+CXSourceLocation_ clang_StringLiteral_getEndLoc(CXStringLiteral SL);
+unsigned clang_StringLiteral_getByteLength(CXStringLiteral SL);
+unsigned clang_StringLiteral_getLength(CXStringLiteral SL);
+unsigned clang_StringLiteral_getCharByteWidth(CXStringLiteral SL);
+
+// ParenExpr
+CXExpr clang_ParenExpr_getSubExpr(CXParenExpr PE);
+CXSourceLocation_ clang_ParenExpr_getLParen(CXParenExpr PE);
+CXSourceLocation_ clang_ParenExpr_getRParen(CXParenExpr PE);
+CXSourceLocation_ clang_ParenExpr_getBeginLoc(CXParenExpr PE);
+CXSourceLocation_ clang_ParenExpr_getEndLoc(CXParenExpr PE);
+
+// UnaryOperator
+CXUnaryOperator clang_UnaryOperator_Create(CXASTContext C, CXExpr Input,
+                                           CXUnaryOperatorKind Opc, CXQualType T,
+                                           CXExprValueKind VK, CXSourceLocation_ L,
+                                           bool CanOverflow);
+CXUnaryOperatorKind clang_UnaryOperator_getOpcode(CXUnaryOperator UO);
+CXExpr clang_UnaryOperator_getSubExpr(CXUnaryOperator UO);
+CXSourceLocation_ clang_UnaryOperator_getOperatorLoc(CXUnaryOperator UO);
+void clang_UnaryOperator_setOperatorLoc(CXUnaryOperator UO, CXSourceLocation_ L);
+CXSourceLocation_ clang_UnaryOperator_getBeginLoc(CXUnaryOperator UO);
+CXSourceLocation_ clang_UnaryOperator_getEndLoc(CXUnaryOperator UO);
+bool clang_UnaryOperator_isPrefix(CXUnaryOperatorKind Opc);
+bool clang_UnaryOperator_isPostfix(CXUnaryOperatorKind Opc);
+bool clang_UnaryOperator_isIncrementDecrementOp(CXUnaryOperatorKind Opc);
+bool clang_UnaryOperator_isArithmeticOp(CXUnaryOperatorKind Opc);
+
+// BinaryOperator
+CXBinaryOperator clang_BinaryOperator_Create(CXASTContext C, CXExpr LHS, CXExpr RHS,
+                                             CXBinaryOperatorKind Opc, CXQualType T,
+                                             CXExprValueKind VK, CXSourceLocation_ L);
+CXBinaryOperatorKind clang_BinaryOperator_getOpcode(CXBinaryOperator BO);
+CXExpr clang_BinaryOperator_getLHS(CXBinaryOperator BO);
+CXExpr clang_BinaryOperator_getRHS(CXBinaryOperator BO);
+CXSourceLocation_ clang_BinaryOperator_getOperatorLoc(CXBinaryOperator BO);
+void clang_BinaryOperator_setOperatorLoc(CXBinaryOperator BO, CXSourceLocation_ L);
+CXSourceLocation_ clang_BinaryOperator_getBeginLoc(CXBinaryOperator BO);
+CXSourceLocation_ clang_BinaryOperator_getEndLoc(CXBinaryOperator BO);
+bool clang_BinaryOperator_isAssignmentOp(CXBinaryOperatorKind Opc);
+bool clang_BinaryOperator_isCompoundAssignmentOp(CXBinaryOperatorKind Opc);
+bool clang_BinaryOperator_isComparisonOp(CXBinaryOperatorKind Opc);
+bool clang_BinaryOperator_isLogicalOp(CXBinaryOperatorKind Opc);
+bool clang_BinaryOperator_isAdditiveOp(CXBinaryOperatorKind Opc);
+bool clang_BinaryOperator_isMultiplicativeOp(CXBinaryOperatorKind Opc);
+
+// CastExpr (base for ImplicitCastExpr, CStyleCastExpr, etc.)
+CXCastKind clang_CastExpr_getCastKind(CXCastExpr CE);
+CXExpr clang_CastExpr_getSubExpr(CXCastExpr CE);
+CXExpr clang_CastExpr_getSubExprAsWritten(CXCastExpr CE);
+
+// ImplicitCastExpr
+CXImplicitCastExpr clang_ImplicitCastExpr_Create(CXASTContext C, CXQualType T,
+                                                  CXCastKind K, CXExpr Op,
+                                                  CXExprValueKind VK);
+CXSourceLocation_ clang_ImplicitCastExpr_getBeginLoc(CXImplicitCastExpr ICE);
+CXSourceLocation_ clang_ImplicitCastExpr_getEndLoc(CXImplicitCastExpr ICE);
 
 // CStyleCastExpr
 CXCStyleCastExpr clang_CStyleCastExpr_CreateWithNoTypeInfo(CXASTContext C, CXQualType T,
                                                            CXExprValueKind VK, CXCastKind K,
                                                            CXExpr Op);
-
 CXCStyleCastExpr clang_CStyleCastExpr_CreateEmpty(CXASTContext C, unsigned PathSize,
                                                   bool HasFPFeatures);
-
 CXSourceLocation_ clang_CStyleCastExpr_getLParenLoc(CXCStyleCastExpr CSCE);
-
 void clang_CStyleCastExpr_setLParenLoc(CXCStyleCastExpr CSCE, CXSourceLocation_ L);
-
 CXSourceLocation_ clang_CStyleCastExpr_getRParenLoc(CXCStyleCastExpr CSCE);
-
 void clang_CStyleCastExpr_setRParenLoc(CXCStyleCastExpr CSCE, CXSourceLocation_ L);
-
 CXSourceLocation_ clang_CStyleCastExpr_getBeginLoc(CXCStyleCastExpr CSCE);
-
 CXSourceLocation_ clang_CStyleCastExpr_getEndLoc(CXCStyleCastExpr CSCE);
+
+// CallExpr
+CXExpr clang_CallExpr_getCallee(CXCallExpr CE);
+unsigned clang_CallExpr_getNumArgs(CXCallExpr CE);
+CXExpr clang_CallExpr_getArg(CXCallExpr CE, unsigned Idx);
+void clang_CallExpr_setArg(CXCallExpr CE, unsigned Idx, CXExpr Arg);
+CXSourceLocation_ clang_CallExpr_getBeginLoc(CXCallExpr CE);
+CXSourceLocation_ clang_CallExpr_getEndLoc(CXCallExpr CE);
+CXQualType clang_CallExpr_getCallReturnType(CXCallExpr CE, CXASTContext Ctx);
+
+// MemberExpr
+CXExpr clang_MemberExpr_getBase(CXMemberExpr ME);
+CXValueDecl clang_MemberExpr_getMemberDecl(CXMemberExpr ME);
+bool clang_MemberExpr_isArrow(CXMemberExpr ME);
+CXSourceLocation_ clang_MemberExpr_getMemberLoc(CXMemberExpr ME);
+CXSourceLocation_ clang_MemberExpr_getBeginLoc(CXMemberExpr ME);
+CXSourceLocation_ clang_MemberExpr_getEndLoc(CXMemberExpr ME);
+
+// ArraySubscriptExpr
+CXExpr clang_ArraySubscriptExpr_getBase(CXArraySubscriptExpr ASE);
+CXExpr clang_ArraySubscriptExpr_getIdx(CXArraySubscriptExpr ASE);
+CXExpr clang_ArraySubscriptExpr_getLHS(CXArraySubscriptExpr ASE);
+CXExpr clang_ArraySubscriptExpr_getRHS(CXArraySubscriptExpr ASE);
+CXSourceLocation_ clang_ArraySubscriptExpr_getBeginLoc(CXArraySubscriptExpr ASE);
+CXSourceLocation_ clang_ArraySubscriptExpr_getEndLoc(CXArraySubscriptExpr ASE);
+
+// ConditionalOperator
+CXExpr clang_ConditionalOperator_getCond(CXConditionalOperator CO);
+CXExpr clang_ConditionalOperator_getTrueExpr(CXConditionalOperator CO);
+CXExpr clang_ConditionalOperator_getFalseExpr(CXConditionalOperator CO);
+CXSourceLocation_ clang_ConditionalOperator_getBeginLoc(CXConditionalOperator CO);
+CXSourceLocation_ clang_ConditionalOperator_getEndLoc(CXConditionalOperator CO);
+
+// InitListExpr
+unsigned clang_InitListExpr_getNumInits(CXInitListExpr ILE);
+CXExpr clang_InitListExpr_getInit(CXInitListExpr ILE, unsigned Idx);
+CXExpr clang_InitListExpr_getArrayFiller(CXInitListExpr ILE);
+bool clang_InitListExpr_hasArrayFiller(CXInitListExpr ILE);
+CXSourceLocation_ clang_InitListExpr_getBeginLoc(CXInitListExpr ILE);
+CXSourceLocation_ clang_InitListExpr_getEndLoc(CXInitListExpr ILE);
 
 LLVM_CLANG_C_EXTERN_C_END
 

--- a/deps/ClangExtra/include/clang-ex/AST/CXOperationKinds.h
+++ b/deps/ClangExtra/include/clang-ex/AST/CXOperationKinds.h
@@ -74,6 +74,59 @@ typedef enum CXCastKind {
   CXCastKind_CK_IntToOCLSampler
 } CXCastKind;
 
+typedef enum CXUnaryOperatorKind {
+  CXUnaryOperatorKind_UO_PostInc,
+  CXUnaryOperatorKind_UO_PostDec,
+  CXUnaryOperatorKind_UO_PreInc,
+  CXUnaryOperatorKind_UO_PreDec,
+  CXUnaryOperatorKind_UO_AddrOf,
+  CXUnaryOperatorKind_UO_Deref,
+  CXUnaryOperatorKind_UO_Plus,
+  CXUnaryOperatorKind_UO_Minus,
+  CXUnaryOperatorKind_UO_Not,
+  CXUnaryOperatorKind_UO_LNot,
+  CXUnaryOperatorKind_UO_Real,
+  CXUnaryOperatorKind_UO_Imag,
+  CXUnaryOperatorKind_UO_Extension,
+  CXUnaryOperatorKind_UO_Coawait,
+} CXUnaryOperatorKind;
+
+typedef enum CXBinaryOperatorKind {
+  CXBinaryOperatorKind_BO_PtrMemD,
+  CXBinaryOperatorKind_BO_PtrMemI,
+  CXBinaryOperatorKind_BO_Mul,
+  CXBinaryOperatorKind_BO_Div,
+  CXBinaryOperatorKind_BO_Rem,
+  CXBinaryOperatorKind_BO_Add,
+  CXBinaryOperatorKind_BO_Sub,
+  CXBinaryOperatorKind_BO_Shl,
+  CXBinaryOperatorKind_BO_Shr,
+  CXBinaryOperatorKind_BO_Cmp,
+  CXBinaryOperatorKind_BO_LT,
+  CXBinaryOperatorKind_BO_GT,
+  CXBinaryOperatorKind_BO_LE,
+  CXBinaryOperatorKind_BO_GE,
+  CXBinaryOperatorKind_BO_EQ,
+  CXBinaryOperatorKind_BO_NE,
+  CXBinaryOperatorKind_BO_And,
+  CXBinaryOperatorKind_BO_Xor,
+  CXBinaryOperatorKind_BO_Or,
+  CXBinaryOperatorKind_BO_LAnd,
+  CXBinaryOperatorKind_BO_LOr,
+  CXBinaryOperatorKind_BO_Assign,
+  CXBinaryOperatorKind_BO_MulAssign,
+  CXBinaryOperatorKind_BO_DivAssign,
+  CXBinaryOperatorKind_BO_RemAssign,
+  CXBinaryOperatorKind_BO_AddAssign,
+  CXBinaryOperatorKind_BO_SubAssign,
+  CXBinaryOperatorKind_BO_ShlAssign,
+  CXBinaryOperatorKind_BO_ShrAssign,
+  CXBinaryOperatorKind_BO_AndAssign,
+  CXBinaryOperatorKind_BO_XorAssign,
+  CXBinaryOperatorKind_BO_OrAssign,
+  CXBinaryOperatorKind_BO_Comma,
+} CXBinaryOperatorKind;
+
 LLVM_CLANG_C_EXTERN_C_END
 
 #endif

--- a/deps/ClangExtra/lib/AST/CXExpr.cpp
+++ b/deps/ClangExtra/lib/AST/CXExpr.cpp
@@ -4,6 +4,99 @@
 #include "clang/Basic/LangOptions.h"
 #include "llvm/ExecutionEngine/GenericValue.h"
 
+// Expr (base)
+CXQualType clang_Expr_getType(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->getType().getAsOpaquePtr();
+}
+
+CXExprValueKind clang_Expr_getValueKind(CXExpr E) {
+  return static_cast<CXExprValueKind>(static_cast<clang::Expr *>(E)->getValueKind());
+}
+
+bool clang_Expr_isLValue(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->isLValue();
+}
+
+bool clang_Expr_isPRValue(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->isPRValue();
+}
+
+bool clang_Expr_isXValue(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->isXValue();
+}
+
+bool clang_Expr_isGLValue(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->isGLValue();
+}
+
+bool clang_Expr_isIntegerConstantExpr(CXExpr E, CXASTContext Ctx) {
+  return static_cast<clang::Expr *>(E)
+      ->isIntegerConstantExpr(*static_cast<clang::ASTContext *>(Ctx))
+      .has_value();
+}
+
+bool clang_Expr_isEvaluatable(CXExpr E, CXASTContext Ctx) {
+  return static_cast<clang::Expr *>(E)->isEvaluatable(
+      *static_cast<clang::ASTContext *>(Ctx));
+}
+
+CXSourceLocation_ clang_Expr_getExprLoc(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->getExprLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_Expr_getBeginLoc(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_Expr_getEndLoc(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->getEndLoc().getPtrEncoding();
+}
+
+CXExpr clang_Expr_IgnoreParens(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->IgnoreParens();
+}
+
+CXExpr clang_Expr_IgnoreImpCasts(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->IgnoreImpCasts();
+}
+
+CXExpr clang_Expr_IgnoreParenImpCasts(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->IgnoreParenImpCasts();
+}
+
+CXExpr clang_Expr_IgnoreCasts(CXExpr E) {
+  return static_cast<clang::Expr *>(E)->IgnoreCasts();
+}
+
+// DeclRefExpr
+CXDeclRefExpr clang_DeclRefExpr_Create(CXASTContext Ctx, CXValueDecl D,
+                                       CXQualType T, CXExprValueKind VK,
+                                       CXSourceLocation_ L) {
+  auto &C = *static_cast<clang::ASTContext *>(Ctx);
+  auto *VD = static_cast<clang::ValueDecl *>(D);
+  return clang::DeclRefExpr::Create(
+      C, clang::NestedNameSpecifierLoc(), clang::SourceLocation(), VD, false,
+      clang::SourceLocation::getFromPtrEncoding(L),
+      clang::QualType::getFromOpaquePtr(T),
+      static_cast<clang::ExprValueKind>(VK));
+}
+
+CXValueDecl clang_DeclRefExpr_getDecl(CXDeclRefExpr E) {
+  return static_cast<clang::DeclRefExpr *>(E)->getDecl();
+}
+
+CXSourceLocation_ clang_DeclRefExpr_getLocation(CXDeclRefExpr E) {
+  return static_cast<clang::DeclRefExpr *>(E)->getLocation().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_DeclRefExpr_getBeginLoc(CXDeclRefExpr E) {
+  return static_cast<clang::DeclRefExpr *>(E)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_DeclRefExpr_getEndLoc(CXDeclRefExpr E) {
+  return static_cast<clang::DeclRefExpr *>(E)->getEndLoc().getPtrEncoding();
+}
+
 // IntegerLiteral
 CXIntegerLiteral clang_IntegerLiteral_Create(CXASTContext C, LLVMGenericValueRef Val,
                                              CXQualType T, CXSourceLocation_ L) {
@@ -28,6 +121,270 @@ CXSourceLocation_ clang_IntegerLiteral_getLocation(CXIntegerLiteral IL) {
 void clang_IntegerLiteral_setLocation(CXIntegerLiteral IL, CXSourceLocation_ L) {
   static_cast<clang::IntegerLiteral *>(IL)->setLocation(
       clang::SourceLocation::getFromPtrEncoding(L));
+}
+
+// FloatingLiteral
+CXFloatingLiteral clang_FloatingLiteral_Create(CXASTContext C, LLVMGenericValueRef Val,
+                                               bool IsExact, CXQualType T,
+                                               CXSourceLocation_ L) {
+  auto &Ctx = *static_cast<clang::ASTContext *>(C);
+  auto QT = clang::QualType::getFromOpaquePtr(T);
+  const llvm::fltSemantics &Sem = Ctx.getFloatTypeSemantics(QT);
+  llvm::APFloat APF(Sem, reinterpret_cast<llvm::GenericValue *>(Val)->DoubleVal);
+  return clang::FloatingLiteral::Create(Ctx, APF, IsExact, QT,
+                                        clang::SourceLocation::getFromPtrEncoding(L));
+}
+
+double clang_FloatingLiteral_getValueAsApproximateDouble(CXFloatingLiteral FL) {
+  return static_cast<clang::FloatingLiteral *>(FL)->getValueAsApproximateDouble();
+}
+
+CXSourceLocation_ clang_FloatingLiteral_getLocation(CXFloatingLiteral FL) {
+  return static_cast<clang::FloatingLiteral *>(FL)->getLocation().getPtrEncoding();
+}
+
+void clang_FloatingLiteral_setLocation(CXFloatingLiteral FL, CXSourceLocation_ L) {
+  static_cast<clang::FloatingLiteral *>(FL)->setLocation(
+      clang::SourceLocation::getFromPtrEncoding(L));
+}
+
+CXSourceLocation_ clang_FloatingLiteral_getBeginLoc(CXFloatingLiteral FL) {
+  return static_cast<clang::FloatingLiteral *>(FL)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_FloatingLiteral_getEndLoc(CXFloatingLiteral FL) {
+  return static_cast<clang::FloatingLiteral *>(FL)->getEndLoc().getPtrEncoding();
+}
+
+// CharacterLiteral
+CXCharacterLiteral clang_CharacterLiteral_Create(CXASTContext C, unsigned Val,
+                                                 CXQualType T, CXSourceLocation_ L) {
+  return new (*static_cast<clang::ASTContext *>(C)) clang::CharacterLiteral(
+      Val, clang::CharacterLiteralKind::Ascii, clang::QualType::getFromOpaquePtr(T),
+      clang::SourceLocation::getFromPtrEncoding(L));
+}
+
+unsigned clang_CharacterLiteral_getValue(CXCharacterLiteral CL) {
+  return static_cast<clang::CharacterLiteral *>(CL)->getValue();
+}
+
+CXSourceLocation_ clang_CharacterLiteral_getLocation(CXCharacterLiteral CL) {
+  return static_cast<clang::CharacterLiteral *>(CL)->getLocation().getPtrEncoding();
+}
+
+void clang_CharacterLiteral_setLocation(CXCharacterLiteral CL, CXSourceLocation_ L) {
+  static_cast<clang::CharacterLiteral *>(CL)->setLocation(
+      clang::SourceLocation::getFromPtrEncoding(L));
+}
+
+CXSourceLocation_ clang_CharacterLiteral_getBeginLoc(CXCharacterLiteral CL) {
+  return static_cast<clang::CharacterLiteral *>(CL)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_CharacterLiteral_getEndLoc(CXCharacterLiteral CL) {
+  return static_cast<clang::CharacterLiteral *>(CL)->getEndLoc().getPtrEncoding();
+}
+
+// StringLiteral
+CXSourceLocation_ clang_StringLiteral_getBeginLoc(CXStringLiteral SL) {
+  return static_cast<clang::StringLiteral *>(SL)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_StringLiteral_getEndLoc(CXStringLiteral SL) {
+  return static_cast<clang::StringLiteral *>(SL)->getEndLoc().getPtrEncoding();
+}
+
+unsigned clang_StringLiteral_getByteLength(CXStringLiteral SL) {
+  return static_cast<clang::StringLiteral *>(SL)->getByteLength();
+}
+
+unsigned clang_StringLiteral_getLength(CXStringLiteral SL) {
+  return static_cast<clang::StringLiteral *>(SL)->getLength();
+}
+
+unsigned clang_StringLiteral_getCharByteWidth(CXStringLiteral SL) {
+  return static_cast<clang::StringLiteral *>(SL)->getCharByteWidth();
+}
+
+// ParenExpr
+CXExpr clang_ParenExpr_getSubExpr(CXParenExpr PE) {
+  return static_cast<clang::ParenExpr *>(PE)->getSubExpr();
+}
+
+CXSourceLocation_ clang_ParenExpr_getLParen(CXParenExpr PE) {
+  return static_cast<clang::ParenExpr *>(PE)->getLParen().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_ParenExpr_getRParen(CXParenExpr PE) {
+  return static_cast<clang::ParenExpr *>(PE)->getRParen().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_ParenExpr_getBeginLoc(CXParenExpr PE) {
+  return static_cast<clang::ParenExpr *>(PE)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_ParenExpr_getEndLoc(CXParenExpr PE) {
+  return static_cast<clang::ParenExpr *>(PE)->getEndLoc().getPtrEncoding();
+}
+
+// UnaryOperator
+CXUnaryOperator clang_UnaryOperator_Create(CXASTContext C, CXExpr Input,
+                                           CXUnaryOperatorKind Opc, CXQualType T,
+                                           CXExprValueKind VK, CXSourceLocation_ L,
+                                           bool CanOverflow) {
+  return clang::UnaryOperator::Create(
+      *static_cast<clang::ASTContext *>(C), static_cast<clang::Expr *>(Input),
+      static_cast<clang::UnaryOperatorKind>(Opc), clang::QualType::getFromOpaquePtr(T),
+      static_cast<clang::ExprValueKind>(VK), clang::OK_Ordinary,
+      clang::SourceLocation::getFromPtrEncoding(L), CanOverflow,
+      clang::FPOptionsOverride());
+}
+
+CXUnaryOperatorKind clang_UnaryOperator_getOpcode(CXUnaryOperator UO) {
+  return static_cast<CXUnaryOperatorKind>(
+      static_cast<clang::UnaryOperator *>(UO)->getOpcode());
+}
+
+CXExpr clang_UnaryOperator_getSubExpr(CXUnaryOperator UO) {
+  return static_cast<clang::UnaryOperator *>(UO)->getSubExpr();
+}
+
+CXSourceLocation_ clang_UnaryOperator_getOperatorLoc(CXUnaryOperator UO) {
+  return static_cast<clang::UnaryOperator *>(UO)->getOperatorLoc().getPtrEncoding();
+}
+
+void clang_UnaryOperator_setOperatorLoc(CXUnaryOperator UO, CXSourceLocation_ L) {
+  static_cast<clang::UnaryOperator *>(UO)->setOperatorLoc(
+      clang::SourceLocation::getFromPtrEncoding(L));
+}
+
+CXSourceLocation_ clang_UnaryOperator_getBeginLoc(CXUnaryOperator UO) {
+  return static_cast<clang::UnaryOperator *>(UO)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_UnaryOperator_getEndLoc(CXUnaryOperator UO) {
+  return static_cast<clang::UnaryOperator *>(UO)->getEndLoc().getPtrEncoding();
+}
+
+bool clang_UnaryOperator_isPrefix(CXUnaryOperatorKind Opc) {
+  return clang::UnaryOperator::isPrefix(static_cast<clang::UnaryOperatorKind>(Opc));
+}
+
+bool clang_UnaryOperator_isPostfix(CXUnaryOperatorKind Opc) {
+  return clang::UnaryOperator::isPostfix(static_cast<clang::UnaryOperatorKind>(Opc));
+}
+
+bool clang_UnaryOperator_isIncrementDecrementOp(CXUnaryOperatorKind Opc) {
+  return clang::UnaryOperator::isIncrementDecrementOp(
+      static_cast<clang::UnaryOperatorKind>(Opc));
+}
+
+bool clang_UnaryOperator_isArithmeticOp(CXUnaryOperatorKind Opc) {
+  return clang::UnaryOperator::isArithmeticOp(
+      static_cast<clang::UnaryOperatorKind>(Opc));
+}
+
+// BinaryOperator
+CXBinaryOperator clang_BinaryOperator_Create(CXASTContext C, CXExpr LHS, CXExpr RHS,
+                                             CXBinaryOperatorKind Opc, CXQualType T,
+                                             CXExprValueKind VK, CXSourceLocation_ L) {
+  return clang::BinaryOperator::Create(
+      *static_cast<clang::ASTContext *>(C), static_cast<clang::Expr *>(LHS),
+      static_cast<clang::Expr *>(RHS), static_cast<clang::BinaryOperatorKind>(Opc),
+      clang::QualType::getFromOpaquePtr(T), static_cast<clang::ExprValueKind>(VK),
+      clang::OK_Ordinary, clang::SourceLocation::getFromPtrEncoding(L),
+      clang::FPOptionsOverride());
+}
+
+CXBinaryOperatorKind clang_BinaryOperator_getOpcode(CXBinaryOperator BO) {
+  return static_cast<CXBinaryOperatorKind>(
+      static_cast<clang::BinaryOperator *>(BO)->getOpcode());
+}
+
+CXExpr clang_BinaryOperator_getLHS(CXBinaryOperator BO) {
+  return static_cast<clang::BinaryOperator *>(BO)->getLHS();
+}
+
+CXExpr clang_BinaryOperator_getRHS(CXBinaryOperator BO) {
+  return static_cast<clang::BinaryOperator *>(BO)->getRHS();
+}
+
+CXSourceLocation_ clang_BinaryOperator_getOperatorLoc(CXBinaryOperator BO) {
+  return static_cast<clang::BinaryOperator *>(BO)->getOperatorLoc().getPtrEncoding();
+}
+
+void clang_BinaryOperator_setOperatorLoc(CXBinaryOperator BO, CXSourceLocation_ L) {
+  static_cast<clang::BinaryOperator *>(BO)->setOperatorLoc(
+      clang::SourceLocation::getFromPtrEncoding(L));
+}
+
+CXSourceLocation_ clang_BinaryOperator_getBeginLoc(CXBinaryOperator BO) {
+  return static_cast<clang::BinaryOperator *>(BO)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_BinaryOperator_getEndLoc(CXBinaryOperator BO) {
+  return static_cast<clang::BinaryOperator *>(BO)->getEndLoc().getPtrEncoding();
+}
+
+bool clang_BinaryOperator_isAssignmentOp(CXBinaryOperatorKind Opc) {
+  return clang::BinaryOperator::isAssignmentOp(
+      static_cast<clang::BinaryOperatorKind>(Opc));
+}
+
+bool clang_BinaryOperator_isCompoundAssignmentOp(CXBinaryOperatorKind Opc) {
+  return clang::BinaryOperator::isCompoundAssignmentOp(
+      static_cast<clang::BinaryOperatorKind>(Opc));
+}
+
+bool clang_BinaryOperator_isComparisonOp(CXBinaryOperatorKind Opc) {
+  return clang::BinaryOperator::isComparisonOp(
+      static_cast<clang::BinaryOperatorKind>(Opc));
+}
+
+bool clang_BinaryOperator_isLogicalOp(CXBinaryOperatorKind Opc) {
+  return clang::BinaryOperator::isLogicalOp(
+      static_cast<clang::BinaryOperatorKind>(Opc));
+}
+
+bool clang_BinaryOperator_isAdditiveOp(CXBinaryOperatorKind Opc) {
+  return clang::BinaryOperator::isAdditiveOp(
+      static_cast<clang::BinaryOperatorKind>(Opc));
+}
+
+bool clang_BinaryOperator_isMultiplicativeOp(CXBinaryOperatorKind Opc) {
+  return clang::BinaryOperator::isMultiplicativeOp(
+      static_cast<clang::BinaryOperatorKind>(Opc));
+}
+
+// CastExpr (base)
+CXCastKind clang_CastExpr_getCastKind(CXCastExpr CE) {
+  return static_cast<CXCastKind>(static_cast<clang::CastExpr *>(CE)->getCastKind());
+}
+
+CXExpr clang_CastExpr_getSubExpr(CXCastExpr CE) {
+  return static_cast<clang::CastExpr *>(CE)->getSubExpr();
+}
+
+CXExpr clang_CastExpr_getSubExprAsWritten(CXCastExpr CE) {
+  return static_cast<clang::CastExpr *>(CE)->getSubExprAsWritten();
+}
+
+// ImplicitCastExpr
+CXImplicitCastExpr clang_ImplicitCastExpr_Create(CXASTContext C, CXQualType T,
+                                                  CXCastKind K, CXExpr Op,
+                                                  CXExprValueKind VK) {
+  return clang::ImplicitCastExpr::Create(
+      *static_cast<clang::ASTContext *>(C), clang::QualType::getFromOpaquePtr(T),
+      static_cast<clang::CastKind>(K), static_cast<clang::Expr *>(Op), nullptr,
+      static_cast<clang::ExprValueKind>(VK), clang::FPOptionsOverride());
+}
+
+CXSourceLocation_ clang_ImplicitCastExpr_getBeginLoc(CXImplicitCastExpr ICE) {
+  return static_cast<clang::ImplicitCastExpr *>(ICE)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_ImplicitCastExpr_getEndLoc(CXImplicitCastExpr ICE) {
+  return static_cast<clang::ImplicitCastExpr *>(ICE)->getEndLoc().getPtrEncoding();
 }
 
 // CStyleCastExpr
@@ -73,4 +430,131 @@ CXSourceLocation_ clang_CStyleCastExpr_getBeginLoc(CXCStyleCastExpr CSCE) {
 
 CXSourceLocation_ clang_CStyleCastExpr_getEndLoc(CXCStyleCastExpr CSCE) {
   return static_cast<clang::CStyleCastExpr *>(CSCE)->getEndLoc().getPtrEncoding();
+}
+
+// CallExpr
+CXExpr clang_CallExpr_getCallee(CXCallExpr CE) {
+  return static_cast<clang::CallExpr *>(CE)->getCallee();
+}
+
+unsigned clang_CallExpr_getNumArgs(CXCallExpr CE) {
+  return static_cast<clang::CallExpr *>(CE)->getNumArgs();
+}
+
+CXExpr clang_CallExpr_getArg(CXCallExpr CE, unsigned Idx) {
+  return static_cast<clang::CallExpr *>(CE)->getArg(Idx);
+}
+
+void clang_CallExpr_setArg(CXCallExpr CE, unsigned Idx, CXExpr Arg) {
+  static_cast<clang::CallExpr *>(CE)->setArg(Idx, static_cast<clang::Expr *>(Arg));
+}
+
+CXSourceLocation_ clang_CallExpr_getBeginLoc(CXCallExpr CE) {
+  return static_cast<clang::CallExpr *>(CE)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_CallExpr_getEndLoc(CXCallExpr CE) {
+  return static_cast<clang::CallExpr *>(CE)->getEndLoc().getPtrEncoding();
+}
+
+CXQualType clang_CallExpr_getCallReturnType(CXCallExpr CE, CXASTContext Ctx) {
+  return static_cast<clang::CallExpr *>(CE)
+      ->getCallReturnType(*static_cast<clang::ASTContext *>(Ctx))
+      .getAsOpaquePtr();
+}
+
+// MemberExpr
+CXExpr clang_MemberExpr_getBase(CXMemberExpr ME) {
+  return static_cast<clang::MemberExpr *>(ME)->getBase();
+}
+
+CXValueDecl clang_MemberExpr_getMemberDecl(CXMemberExpr ME) {
+  return static_cast<clang::MemberExpr *>(ME)->getMemberDecl();
+}
+
+bool clang_MemberExpr_isArrow(CXMemberExpr ME) {
+  return static_cast<clang::MemberExpr *>(ME)->isArrow();
+}
+
+CXSourceLocation_ clang_MemberExpr_getMemberLoc(CXMemberExpr ME) {
+  return static_cast<clang::MemberExpr *>(ME)->getMemberLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_MemberExpr_getBeginLoc(CXMemberExpr ME) {
+  return static_cast<clang::MemberExpr *>(ME)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_MemberExpr_getEndLoc(CXMemberExpr ME) {
+  return static_cast<clang::MemberExpr *>(ME)->getEndLoc().getPtrEncoding();
+}
+
+// ArraySubscriptExpr
+CXExpr clang_ArraySubscriptExpr_getBase(CXArraySubscriptExpr ASE) {
+  return static_cast<clang::ArraySubscriptExpr *>(ASE)->getBase();
+}
+
+CXExpr clang_ArraySubscriptExpr_getIdx(CXArraySubscriptExpr ASE) {
+  return static_cast<clang::ArraySubscriptExpr *>(ASE)->getIdx();
+}
+
+CXExpr clang_ArraySubscriptExpr_getLHS(CXArraySubscriptExpr ASE) {
+  return static_cast<clang::ArraySubscriptExpr *>(ASE)->getLHS();
+}
+
+CXExpr clang_ArraySubscriptExpr_getRHS(CXArraySubscriptExpr ASE) {
+  return static_cast<clang::ArraySubscriptExpr *>(ASE)->getRHS();
+}
+
+CXSourceLocation_ clang_ArraySubscriptExpr_getBeginLoc(CXArraySubscriptExpr ASE) {
+  return static_cast<clang::ArraySubscriptExpr *>(ASE)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_ArraySubscriptExpr_getEndLoc(CXArraySubscriptExpr ASE) {
+  return static_cast<clang::ArraySubscriptExpr *>(ASE)->getEndLoc().getPtrEncoding();
+}
+
+// ConditionalOperator
+CXExpr clang_ConditionalOperator_getCond(CXConditionalOperator CO) {
+  return static_cast<clang::ConditionalOperator *>(CO)->getCond();
+}
+
+CXExpr clang_ConditionalOperator_getTrueExpr(CXConditionalOperator CO) {
+  return static_cast<clang::ConditionalOperator *>(CO)->getTrueExpr();
+}
+
+CXExpr clang_ConditionalOperator_getFalseExpr(CXConditionalOperator CO) {
+  return static_cast<clang::ConditionalOperator *>(CO)->getFalseExpr();
+}
+
+CXSourceLocation_ clang_ConditionalOperator_getBeginLoc(CXConditionalOperator CO) {
+  return static_cast<clang::ConditionalOperator *>(CO)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_ConditionalOperator_getEndLoc(CXConditionalOperator CO) {
+  return static_cast<clang::ConditionalOperator *>(CO)->getEndLoc().getPtrEncoding();
+}
+
+// InitListExpr
+unsigned clang_InitListExpr_getNumInits(CXInitListExpr ILE) {
+  return static_cast<clang::InitListExpr *>(ILE)->getNumInits();
+}
+
+CXExpr clang_InitListExpr_getInit(CXInitListExpr ILE, unsigned Idx) {
+  return static_cast<clang::InitListExpr *>(ILE)->getInit(Idx);
+}
+
+CXExpr clang_InitListExpr_getArrayFiller(CXInitListExpr ILE) {
+  return static_cast<clang::InitListExpr *>(ILE)->getArrayFiller();
+}
+
+bool clang_InitListExpr_hasArrayFiller(CXInitListExpr ILE) {
+  return static_cast<clang::InitListExpr *>(ILE)->hasArrayFiller();
+}
+
+CXSourceLocation_ clang_InitListExpr_getBeginLoc(CXInitListExpr ILE) {
+  return static_cast<clang::InitListExpr *>(ILE)->getBeginLoc().getPtrEncoding();
+}
+
+CXSourceLocation_ clang_InitListExpr_getEndLoc(CXInitListExpr ILE) {
+  return static_cast<clang::InitListExpr *>(ILE)->getEndLoc().getPtrEncoding();
 }


### PR DESCRIPTION
## Summary

This PR significantly expands the libclangex C API surface by adding 150+ new wrapper functions for Clang's expression AST nodes and operator kinds. These additions enable Julia code to construct, inspect, and manipulate C++ expressions at the AST level, completing the expression handling capabilities of the library.

## Key Changes

### New Expression Type Wrappers (CXExpr.cpp/h)

**Base Expr class:**
- Type and value kind queries: `clang_Expr_getType`, `clang_Expr_getValueKind`, `clang_Expr_isLValue`, `clang_Expr_isPRValue`, `clang_Expr_isXValue`, `clang_Expr_isGLValue`
- Constant expression evaluation: `clang_Expr_isIntegerConstantExpr`, `clang_Expr_isEvaluatable`
- Source location accessors: `clang_Expr_getExprLoc`, `clang_Expr_getBeginLoc`, `clang_Expr_getEndLoc`
- Expression simplification: `clang_Expr_IgnoreParens`, `clang_Expr_IgnoreImpCasts`, `clang_Expr_IgnoreParenImpCasts`, `clang_Expr_IgnoreCasts`

**DeclRefExpr:**
- Construction and introspection: `clang_DeclRefExpr_Create`, `clang_DeclRefExpr_getDecl`, location accessors

**Literal types:**
- `FloatingLiteral`: creation, value retrieval, location management
- `CharacterLiteral`: creation, value retrieval, location management
- `StringLiteral`: length queries, character width inspection

**Operator expressions:**
- `ParenExpr`: sub-expression and parenthesis location accessors
- `UnaryOperator`: creation, opcode queries, operator classification predicates (`isPrefix`, `isPostfix`, `isIncrementDecrementOp`, `isArithmeticOp`)
- `BinaryOperator`: creation, operand/opcode accessors, operator classification predicates (`isAssignmentOp`, `isCompoundAssignmentOp`, `isComparisonOp`, `isLogicalOp`, `isAdditiveOp`, `isMultiplicativeOp`)

**Cast expressions:**
- `CastExpr` (base): `clang_CastExpr_getCastKind`, `clang_CastExpr_getSubExpr`, `clang_CastExpr_getSubExprAsWritten`
- `ImplicitCastExpr`: creation and location accessors

**Other expression types:**
- `CallExpr`: callee/argument accessors, return type queries
- `MemberExpr`: base/member accessors, arrow operator detection
- `ArraySubscriptExpr`: base/index accessors
- `ConditionalOperator`: condition/branch accessors
- `InitListExpr`: initializer iteration, array filler support

### New Operator Kind Enums (CXOperationKinds.h)

- `CXUnaryOperatorKind`: 14 unary operators (PostInc, PreInc, AddrOf, Deref, Plus, Minus, Not, LNot, Real, Imag, Extension, Coawait)
- `CXBinaryOperatorKind`: 33 binary operators (arithmetic, comparison, logical, bitwise, assignment variants, comma)

### Documentation

Added `SUMMARY.md` providing comprehensive project overview including architecture, component descriptions, API coverage statistics, and usage examples.

## Implementation Details

- All expression creation functions properly initialize Clang AST nodes with appropriate default parameters (e.g., `FPOptionsOverride()`, `OK_Ordinary` for ObjectKind)
- Source location conversions use the established `getPtrEncoding()`/`getFromPtrEncoding()` pattern for opaque pointer handling
- Operator classification functions are exposed as static predicates for both unary and binary operators
- Expression simplification methods (Ignore*) enable AST traversal without syntactic noise

https://claude.ai/code/session_01DdXiLtACUvEgJfa3zTGiRE