### PR TITLE
Fix CI on all platforms: msys2 toolchain fixes, Julia 1.12 pin, local ClangExtra build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,10 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           path-type: inherit
-          install: mingw-w64-x86_64-gcc
+          # `make` (msys) is required so CMake's "MSYS Makefiles" generator picks
+          # msys2's own make instead of the runner image's C:/mingw64/bin/make.exe,
+          # which is on the inherited PATH and cannot drive msys2's compilers.
+          install: mingw-w64-x86_64-gcc make
         if: runner.os == 'Windows'
 
       - name: Build ClangExtra

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,13 +58,20 @@ jobs:
           install: mingw-w64-x86_64-gcc make
         if: runner.os == 'Windows'
 
+      # Build ClangExtra unconditionally (build_local.jl) instead of relying on
+      # build_ci.jl's timestamp heuristic: libclangex_jll v0.2.0+1 is a rebuild of
+      # the pre-2025-07 v0.2.0 sources, so a newer JLL tag does not imply it
+      # contains the current wrappers. Its clang_Interpreter_getSymbolAddress
+      # returns the address of a dead stack temporary (nulled by GCC), breaking
+      # the execution tests. Revert to build_ci.jl once a JLL built from the
+      # current ClangExtra sources is tagged.
       - name: Build ClangExtra
-        run: julia --project=deps deps/build_ci.jl
+        run: julia --project=deps deps/build_local.jl
         if: runner.os != 'Windows'
 
       - name: Build ClangExtra (in msys2)
         shell: msys2 {0}
-        run: julia --project=deps deps/build_ci.jl
+        run: julia --project=deps deps/build_local.jl
         if: runner.os == 'Windows'
 
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'pre'
-          # - '1.12'
+          - '1.12'
+          # - 'pre'
           # - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,9 @@ jobs:
           # `make` (msys) is required so CMake's "MSYS Makefiles" generator picks
           # msys2's own make instead of the runner image's C:/mingw64/bin/make.exe,
           # which is on the inherited PATH and cannot drive msys2's compilers.
-          install: mingw-w64-x86_64-gcc make
+          # `mingw-w64-x86_64-cmake` lets build_local.jl avoid CMake_jll's wrapper,
+          # whose PATH injection breaks gcc's subprocesses (see build_local.jl).
+          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake make
         if: runner.os == 'Windows'
 
       # Build ClangExtra unconditionally (build_local.jl) instead of relying on

--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -48,7 +48,7 @@ Clang_DIR = joinpath(LLVM.artifact_dir, "lib", "cmake", "clang")
 
 # build and install
 @info "Building" source_dir scratch_dir build_dir LLVM_DIR Clang_DIR
-cmake() do cmake_path
+function build_clangex(cmake_path)
     config_opts = `-DLLVM_DIR=$(LLVM_DIR) -DClang_DIR=$(Clang_DIR) -DCMAKE_INSTALL_PREFIX=$(scratch_dir)`
     if Sys.iswindows()
         # prevent picking up MSVC
@@ -56,6 +56,20 @@ cmake() do cmake_path
     end
     run(`$cmake_path $config_opts -B$(build_dir) -S$(source_dir)`)
     run(`$cmake_path --build $(build_dir) --target install --parallel $(Sys.CPU_THREADS)`)
+end
+
+# In an MSYS2 shell, use the environment's own cmake instead of CMake_jll's:
+# JLLWrappers uses PATH as the library path on Windows and prepends the
+# artifact DLL directories to it, so gcc subprocesses spawned by the
+# JLL-wrapped cmake resolve mismatched runtime DLLs from those directories
+# and fail without a diagnostic.
+msys2_cmake = Sys.iswindows() && haskey(ENV, "MSYSTEM") ? Sys.which("cmake") : nothing
+if msys2_cmake !== nothing
+    build_clangex(msys2_cmake)
+else
+    cmake() do cmake_path
+        build_clangex(cmake_path)
+    end
 end
 
 # discover built libraries

--- a/src/compiler/interpreter.jl
+++ b/src/compiler/interpreter.jl
@@ -41,7 +41,12 @@ get_sema(x::CxxInterpreter) = getSema(get_parser(x))
 get_execution_engine(x::CxxInterpreter) = getExecutionEngine(x.interp)
 get_symbol_address(x::CxxInterpreter, name::AbstractString) = getSymbolAddress(x.interp, name)
 get_symbol_address_from_linker_name(x::CxxInterpreter, name::AbstractString) = getSymbolAddressFromLinkerName(x.interp, name)
-get_function_pointer(x::CxxInterpreter, name::AbstractString) = Ptr{Cvoid}(get_symbol_address(x, name))
+function get_function_pointer(x::CxxInterpreter, name::AbstractString)
+    addr = get_symbol_address(x, name)
+    iszero(addr) &&
+        error("failed to resolve the address of `$name`; the symbol may not be JIT-compiled yet or the loaded libclangex is incompatible.")
+    return Ptr{Cvoid}(addr)
+end
 
 parse(x::CxxInterpreter, code::String) = Parse(x.interp, code)
 execute(x::CxxInterpreter, tu::PartialTranslationUnit) = Execute(x.interp, tu)


### PR DESCRIPTION
Makes CI green on ubuntu, macOS, and Windows (all red before this PR — Windows since mid-2025). Verified: [run 29671750554](https://github.com/Gnimuc/ClangCompiler.jl/actions/runs/29671750554) passes on all three platforms.

Three independent problems were stacked on top of each other:

## 1. Windows: silent failure of CMake's compiler sanity check

The "Build ClangExtra (in msys2)" step failed with `The C++ compiler ... is not able to compile a simple test program` and a bare `make Error 1`, no compiler diagnostic. Two toolchain-mixing issues:

- **Foreign `make`**: the msys2 environment installed only `mingw-w64-x86_64-gcc`, so CMake's `"MSYS Makefiles"` generator resolved `make` from the runner image's other MinGW at `C:/mingw64/bin` (on the inherited PATH via `path-type: inherit`). Fixed by installing msys2's `make`, which wins the PATH lookup since msys2 paths come first.
- **DLL shadowing via CMake_jll's wrapper** (the actual cause of the silent compiler death): JLLWrappers uses `PATH` as the library path on Windows and *prepends* the artifact DLL directories to it. Every process spawned under the JLL-wrapped `cmake` (make → sh → c++ → cc1plus) inherited that PATH, and gcc's subprocesses resolved mismatched runtime DLLs from the artifact directories and exited without printing anything. Fixed by installing `mingw-w64-x86_64-cmake` and preferring the MSYS2 environment's own cmake in `build_local.jl` when running inside MSYS2 (its DLLs live in the same `mingw64/bin` as gcc); CMake_jll remains the fallback everywhere else.

`path-type: inherit` is kept — Julia must remain reachable inside the msys2 shell.

## 2. All platforms: `'pre'` resolved to Julia 1.13 / LLVM 20

The package only ships `lib/18` wrappers, so precompilation failed opening `lib/20/LibClangEx.jl` on every OS. The matrix is now pinned to `'1.12'` (LLVM 18).

## 3. All platforms: stale `libclangex_jll v0.2.0+1`

`v0.2.0+1` (tagged 2026-05-14) is a rebuild of the pre-2025-07 `v0.2.0` sources, so `build_ci.jl`'s timestamp heuristic wrongly concluded the JLL contains the current wrappers. That binary's `clang_Interpreter_getSymbolAddress` still ends with `return &*Addr;` (address of a local `Expected` payload), which GCC's `-Wreturn-local-addr` optimization folds to null — confirmed by disassembly: the success path is `xor %eax,%eax; ret`. Every symbol lookup silently returned 0 and the execution tests died with a cryptic `UndefRefError` at the `ccall`. Changes:

- CI runs `deps/build_local.jl` unconditionally until a JLL built from the current `ClangExtra` sources is tagged (then this can be reverted to `build_ci.jl`).
- `get_function_pointer` now raises a descriptive error on a failed lookup instead of returning a null pointer.

**Follow-up for the maintainer:** `libclangex_jll v0.2.0+1` is broken for anyone using it — a new JLL (e.g. v0.2.1) should be built from the current `ClangExtra` sources via Yggdrasil, after which CI can return to the `build_ci.jl` fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012B6oU84Rhqpx889fh2KUnF