### PR TITLE
Exercise the ASTNameGenerator wrappers the placeholder only type-checked

### DIFF
--- a/test/clang/api/AST/Mangle.jl
+++ b/test/clang/api/AST/Mangle.jl
@@ -61,7 +61,7 @@ end
     # complete-object (C1) constructors under the Itanium family every resolved target
     # uses.
     @test f(I, "NgWidget")
-    ctor = first(CC.getCtors(CC.CXXRecordDecl(get_decl(f))))
+    ctor = only(c for c in CC.getCtors(CC.CXXRecordDecl(get_decl(f))) if CC.isDefaultConstructor(c))
     manglings = CC.getAllManglings(g, ctor)
     @test any(endswith("_ZN8NgWidgetC1Ev"), manglings)
     @test any(endswith("_ZN8NgWidgetC2Ev"), manglings)

--- a/test/clang/api/AST/Mangle.jl
+++ b/test/clang/api/AST/Mangle.jl
@@ -37,10 +37,39 @@ using Libdl
     dispose(I)
 end
 
-@testset "mangling name generator surface" begin
-    # No creator for clang::ASTNameGenerator crosses the C boundary yet, so only the
-    # method surface is checkable here.
-    @test hasmethod(CC.getAllManglings, Tuple{CC.ASTNameGenerator,CC.FunctionDecl})
+@testset "ASTNameGenerator" begin
+    I = create_interpreter(String[])
+    ctx = CC.get_ast_context(I)
+    g = CC.ASTNameGenerator(ctx)
+    mc = CC.createMangleContext(ctx, CC.getTargetInfo(ctx))
+    f = DeclFinder(I)
+    # Primitive signatures keep the Itanium spelling target-stable; the generator layers
+    # the backend mangling on top, so its result carries the data layout's global prefix
+    # (`_` on Mach-O, none on ELF/COFF) — assert the frontend suffix, never the whole
+    # string.
+    CC.parse(I, "int ng_mul(int a, int b) { return a * b; } struct NgWidget { NgWidget(); };")
+
+    @test f(I, "ng_mul")
+    mul_nd = get_decl(f)
+    @test endswith(CC.getName(g, mul_nd), "_Z6ng_mulii")
+    # ...and that suffix is exactly the frontend mangling, on every C++ ABI.
+    @test endswith(CC.getName(g, mul_nd), CC.mangleName(mc, mul_nd))
+    # getAllManglings enumerates structor/method variants only; a plain function has none.
+    @test CC.getAllManglings(g, mul_nd) == String[]
+
+    # A constructor mangles once per structor variant — the base-object (C2) and
+    # complete-object (C1) constructors under the Itanium family every resolved target
+    # uses.
+    @test f(I, "NgWidget")
+    ctor = first(CC.getCtors(CC.CXXRecordDecl(get_decl(f))))
+    manglings = CC.getAllManglings(g, ctor)
+    @test any(endswith("_ZN8NgWidgetC1Ev"), manglings)
+    @test any(endswith("_ZN8NgWidgetC2Ev"), manglings)
+
+    dispose(f)
+    CC.dispose(mc)
+    CC.dispose(g)
+    dispose(I)
 end
 
 @testset "Coverage | MangleContext tail" begin


### PR DESCRIPTION
## What

Replaces the stale placeholder testset `"mangling name generator surface"` in `test/clang/api/AST/Mangle.jl` with a real create → use → dispose test of the `ASTNameGenerator` wrappers.

The placeholder predated the factory and could only assert `hasmethod`, with a comment claiming "No creator for clang::ASTNameGenerator crosses the C boundary yet" — no longer true since `clang_ASTNameGenerator_create`/`_dispose` landed. `test/highlevel.jl` already exercises `getAllManglings`, but nothing called `getName(::ASTNameGenerator, ::AbstractDecl)` at all.

## The assertions

- `getName` is pinned to the Itanium spelling with `endswith`, and additionally asserted to end with exactly `mangleName`'s output — an invariant that holds on every C++ ABI.
- `getAllManglings` is pinned to `String[]` for a plain function (it only enumerates structor/method variants) and to the exact `C1`/`C2` suffixes for a constructor — stronger than highlevel.jl's `length ≥ 2` / `occursin` checks.

## Reviewer note — why `endswith`, not `==`

Unlike `MangleContext`, `ASTNameGenerator` applies the backend mangling on top of the frontend one, so its results carry the data layout's global prefix: `_` on Mach-O, none on ELF/mingw-COFF. An exact match passes on whichever platform you develop on and reds the other two runners. Primitive-only signatures keep the frontend part target-stable, per the suite's existing convention.

Test-only change; no C or wrapper code touched. Verified with a standalone TestEnv run against a local build of current `main` and a full green `Pkg.test()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)