### PR TITLE
Define the STDC macros LLVM exports in LLVM_DEFINITIONS, fixing the old-glibc Ygg builds

### DIFF
--- a/deps/ClangExtra/CMakeLists.txt
+++ b/deps/ClangExtra/CMakeLists.txt
@@ -54,6 +54,15 @@ endif(WIN32)
 # lets the shim spell `int64_t` at its own boundary with no truncation anywhere.
 target_compile_definitions(clangex PUBLIC "_FILE_OFFSET_BITS=64")
 
+# The three definitions LLVMConfig.cmake exports in LLVM_DEFINITIONS. LLVM headers use the
+# C99 PRI* format macros ("%" PRIu64 in BitstreamReader.h), and glibc before 2.18 defines
+# those in C++ only when __STDC_FORMAT_MACROS is set before <inttypes.h> first arrives --
+# the x86_64, i686 and powerpc64le BinaryBuilder sysroots (glibc 2.12/2.17) are that old.
+# GCC's own <stdint.h> wrapper supplies the LIMIT/CONSTANT pair in C++11 mode, but it has
+# no <inttypes.h> counterpart, so only the FORMAT macro ever goes missing; all three are
+# spelled here because they are one contract.
+target_compile_definitions(clangex PUBLIC "__STDC_CONSTANT_MACROS" "__STDC_FORMAT_MACROS" "__STDC_LIMIT_MACROS")
+
 target_link_libraries(clangex LINK_PUBLIC LLVM clang-cpp)
 
 include(cmake/install_config.cmake)


### PR DESCRIPTION
## What changed

One `target_compile_definitions` line (plus its comment) in `deps/ClangExtra/CMakeLists.txt`: the three `__STDC_*_MACROS` definitions that LLVM's `LLVMConfig.cmake` exports in `LLVM_DEFINITIONS`, placed beside the existing `_FILE_OFFSET_BITS=64` toolchain-agreement define. No header changed, so the generated bindings under `lib/` are untouched.

## Why

The Yggdrasil `libclangex` build fails on exactly `i686-linux-gnu-cxx11`, `x86_64-linux-gnu-cxx11`, and `powerpc64le-linux-gnu-cxx11`, with GCC dying inside `llvm/Bitstream/BitstreamReader.h` in `BitstreamCursor::SkipBlock()`. The chain:

- e08a2f1 added `#include "clang/Serialization/ASTReader.h"` to `CXCompilerInstance.cpp` (for the `createPCHExternalASTSource`/`hasASTReader` wrappers) — the tree's only `Serialization/` include, so this is the first TU to reach `BitstreamReader.h`.
- That header's inline `SkipBlock()` uses `"%" PRIu64` in a `createStringError` format string.
- glibc before 2.18 defines the C99 `PRI*` macros in C++ only when `__STDC_FORMAT_MACROS` is defined before `<inttypes.h>` is first included. The failing set is precisely the BinaryBuilder sysroots that old — x86_64/i686 (glibc 2.12.2) and powerpc64le (2.17) — while aarch64/armv7l shards (glibc 2.19), musl, mingw-w64, and the clang-built macOS/FreeBSD targets define `PRI*` unconditionally.
- With the macro undefined, `"..." PRIu64` is a string literal followed by a stray identifier: a hard syntax error, which is why it fires even though sysroot headers suppress ordinary warnings.

The subtle part — why only this macro family, when `UINT64_MAX`/`INT64_C` sit behind the same old-glibc guards and `llvm-c/DataTypes.h` even `#error`s without them: GCC installs its own `<stdint.h>` wrapper that pre-defines `__STDC_LIMIT_MACROS`/`__STDC_CONSTANT_MACROS` in C++11 mode before `#include_next`-ing glibc's, but ships no `<inttypes.h>` counterpart. So the whole library built fine on those shards for years until an include chain first touched a `PRI*` use. All three macros are applied here because they are one contract (and the stdint rescue is a GCC implementation detail); they are no-ops on every libc that was already passing.

## Reviewer notes

- Verified locally by a configure-only run against the pinned LLVM 18.1.7 artifact: `CXX_DEFINES` now carries `-D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS`, which the failing Ygg compile lines lacked.
- GitHub CI cannot exercise the actual failure — every runner has a modern libc. The real test is the Yggdrasil rebuild on the three old-glibc shards; the `L/libclangex` recipe needs to point at a commit containing this change.
- This commit touches `deps/ClangExtra`, so CI will rebuild libclangex from source via `build_ci.jl` (expected), and a `libclangex_jll` bump is required before the next ClangCompiler.jl release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)