### PR TITLE
Fix three audit measurements that could not fail, and assert what they were hiding

### DIFF
--- a/.claude/skills/suite-audit/SKILL.md
+++ b/.claude/skills/suite-audit/SKILL.md
@@ -74,7 +74,7 @@ Know the ceiling of the thing you are about to rely on:
   entirely and every `# shape-only` marker was decorative — a broken detector prints the same
   clean sentence a clean tree does, which is why `self_check()` now runs first and why you
   should reach for the four-probe test in this skill's history before believing a green run.
-  And it validates that a marker *names* one of the three admitted reasons, never that the
+  And it validates that a marker *names* one of the four admitted reasons, never that the
   reason is true: a source-decided value excused as target-decided passes.
 - **Metamorphic invariants** (`test/clang/invariants.jl`) assert relationships that hold over
   any AST — a parent's range contains its children's, a binary operator's operands are distinct
@@ -82,12 +82,19 @@ Know the ceiling of the thing you are about to rely on:
   score from 28.6% to 85.7%; one invariant is worth a hundred value assertions.
 - **A saturated catalogue is not an instrument.** The score read 100% while all nine mutants sat
   in AST core and ran only `AST_CORE` files, so it described `Expr`/`Decl`/`Stmt` and nothing
-  else. It has now been extended twice, and each time the number fell the moment it reached
-  somewhere new: to 62.5% over `CompilerInstance.jl` and `Driver.jl` (six of seven survived),
-  then to 70.8% over `SourceManager.jl`, `ASTUnit.jl`, `Comment.jl` and `IdentifierTable.jl`
-  (seven of eight). Both rounds are fixed; it reads 95.8% across 24. Extend the catalogue into
-  a region *before* concluding anything about that region — `CFG`, `Lex` and the rest of
-  `Sema` have still never had a fault injected.
+  else. It has been extended three times, and the number fell every time it reached somewhere
+  new: 62.5% over `CompilerInstance.jl` and `Driver.jl` (six of seven survived), 70.8% over
+  `SourceManager.jl`, `ASTUnit.jl`, `Comment.jl` and `IdentifierTable.jl` (seven of eight),
+  then `CFG`, `Lex` and `Sema` (three of eight). All fixed; it reads 93.8% across 32. Extend
+  the catalogue into a region *before* concluding anything about that region — `Type.jl`,
+  `ExprCXX.jl`, `DeclCXX.jl`, `DeclTemplate.jl` and `APValue.jl` have still never had a fault
+  injected, which is tracked in #51.
+- **A score measured against a red tree only goes up.** Detection here is "a `Test Failed`
+  appeared", which cannot separate a mutant being caught from a suite that was already
+  failing: one broken assertion marks every mutant over that file set as caught. A wrong
+  expected value once reported two genuine survivors as caught in the run that introduced it.
+  `check_baseline` now runs each file set unmutated first and exits 3 rather than scoring a
+  red tree — so never quote a number from a run that did not print the baseline line.
 - **A survivor is sometimes a missing capability, not a missing assertion.** `getMainFileName`
   and `getOriginalSourceFileName` agree in every state this suite can build — both empty before
   a parse, both the `.cpp` after one — so no assertion at either site can separate them. They

--- a/.claude/skills/suite-audit/SKILL.md
+++ b/.claude/skills/suite-audit/SKILL.md
@@ -69,10 +69,33 @@ Know the ceiling of the thing you are about to rely on:
   bug.
 - **`isa` assertions** cannot separate two results of the same type. `getBeginLoc` returning the
   end location passes every one of them. This is what `test/tautologies.jl` exists to find.
+  Two things about that detector are worth knowing before trusting its output. It once matched
+  its pattern against the whole line, so any assertion carrying a trailing comment escaped
+  entirely and every `# shape-only` marker was decorative — a broken detector prints the same
+  clean sentence a clean tree does, which is why `self_check()` now runs first and why you
+  should reach for the four-probe test in this skill's history before believing a green run.
+  And it validates that a marker *names* one of the three admitted reasons, never that the
+  reason is true: a source-decided value excused as target-decided passes.
 - **Metamorphic invariants** (`test/clang/invariants.jl`) assert relationships that hold over
   any AST — a parent's range contains its children's, a binary operator's operands are distinct
   nodes. They need no captured values and no per-platform care. Five testsets took the mutation
   score from 28.6% to 85.7%; one invariant is worth a hundred value assertions.
+- **A saturated catalogue is not an instrument.** The score read 100% while all nine mutants sat
+  in AST core and ran only `AST_CORE` files, so it described `Expr`/`Decl`/`Stmt` and nothing
+  else. It has now been extended twice, and each time the number fell the moment it reached
+  somewhere new: to 62.5% over `CompilerInstance.jl` and `Driver.jl` (six of seven survived),
+  then to 70.8% over `SourceManager.jl`, `ASTUnit.jl`, `Comment.jl` and `IdentifierTable.jl`
+  (seven of eight). Both rounds are fixed; it reads 95.8% across 24. Extend the catalogue into
+  a region *before* concluding anything about that region — `CFG`, `Lex` and the rest of
+  `Sema` have still never had a fault injected.
+- **A survivor is sometimes a missing capability, not a missing assertion.** `getMainFileName`
+  and `getOriginalSourceFileName` agree in every state this suite can build — both empty before
+  a parse, both the `.cpp` after one — so no assertion at either site can separate them. They
+  diverge only after `ASTUnit::LoadFromASTFile`, which has no wrapper. That mutant carries a
+  `blocked_on` note naming exactly that, still counts against the score, and keeps the exit
+  status meaningful so a red run means something *new* survived. The script fails just as
+  loudly if a blocked mutant starts being caught, because that note is then stale — the same
+  rot that turned 152 `# shape-only` markers into decoration.
 - **Invariants still have a ceiling**: they check the shim's answers against each other, so a
   *consistently* wrong shim satisfies them. Swap `getBeginLoc` and `getEndLoc` together and
   containment still holds, because containment is symmetric. Measured: invariants report 0

--- a/.claude/skills/suite-audit/mutants.jl
+++ b/.claude/skills/suite-audit/mutants.jl
@@ -44,12 +44,35 @@ struct Mutant
     mutation::String        # evaluated inside the ClangCompiler module
     files::Vector{String}   # test files to run
     note::String            # the real bug class this stands in for
+    # Non-empty marks a mutant known to survive, naming the capability the suite would need
+    # to kill it. It still counts against the score -- an exemption that improved the number
+    # would be a way of hiding the gap rather than recording it -- but it keeps the exit
+    # status meaningful, so a red run means something NEW survived. The script fails just as
+    # loudly when a blocked mutant starts being caught, because the note is then stale and
+    # this field is the kind of exemption that rots if nothing checks it.
+    blocked_on::String
 end
+Mutant(l, m, f, n) = Mutant(l, m, f, n, "")
 
 const AST_CORE = ["test/clang/invariants.jl", "test/clang/differential.jl",
                   "test/clang/api/AST/Expr.jl",
                   "test/clang/api/AST/Decl.jl", "test/clang/api/AST/DeclBase.jl",
                   "test/clang/decl.jl", "test/clang/stmt.jl"]
+
+# The two files holding the most `# shape-only` markers, and -- until these mutants -- the
+# largest stretch of the wrapper surface no fault had ever been injected into. A score
+# measured only over AST_CORE says nothing about either.
+const FRONTEND = ["test/clang/api/Frontend/CompilerInstance.jl"]
+const DRIVER = ["test/clang/api/Driver/Driver.jl"]
+const SOURCEMGR = ["test/clang/api/Basic/SourceManager.jl"]
+const ASTUNIT = ["test/clang/api/Frontend/ASTUnit.jl"]
+const COMMENT = ["test/clang/api/AST/Comment.jl"]
+const IDTABLE = ["test/clang/api/Basic/IdentifierTable.jl"]
+const CFGF = ["test/clang/api/Analysis/CFG.jl"]
+const LEX = ["test/clang/api/Lex/Preprocessor.jl"]
+const SEMA = ["test/clang/api/Sema/Sema.jl", "test/clang/api/Sema/Lookup.jl",
+              "test/clang/api/Sema/TemplateDeduction.jl"]
+const SRCLOC = ["test/clang/api/Basic/SourceLocation.jl"]
 
 const CATALOGUE = [
     Mutant("swap_begin_end",
@@ -84,23 +107,143 @@ const CATALOGUE = [
            "getArg(x::AbstractCallExpr, i::Integer) = Expr_(clang_CallExpr_getArg(x, 0))",
            AST_CORE,
            "an index ignored -- what argument misrouting in a void* shim looks like"),
+    Mutant("lookup_name_always_found",
+           "LookupName(x::Sema, r::LookupResult, sp::Scope, allow_builtin_creation::Bool=false, force_no_cxx::Bool=false) = true",
+           FRONTEND,
+           "a Sema query answering yes whatever the lookup found"),
+    Mutant("lookup_count_zero",
+           "getNum(x::LookupResult) = 0", FRONTEND,
+           "a count swallowed -- the shape of a shim reading the wrong field"),
+    Mutant("scopespec_validity_collapse",
+           "isInvalid(x::CXXScopeSpec) = isValid(x)", FRONTEND,
+           "two complementary predicates wired to the same underlying query"),
+    Mutant("scopespec_emptiness_collapse",
+           "isNotEmpty(x::CXXScopeSpec) = isEmpty(x)", FRONTEND,
+           "the same, on the emptiness pair"),
+    Mutant("driver_sysroot_swap",
+           "getSysRoot(x::AbstractDriver) = getResourceDir(x)", DRIVER,
+           "a string accessor returning a sibling member -- `isa String` cannot see it"),
+    Mutant("toolchain_arch_os_swap",
+           "getArchName(x::AbstractToolChain) = getOS(x)", DRIVER,
+           "the same, on the two components a toolchain reads out of its triple"),
+    Mutant("driver_lto_always",
+           "isUsingLTO(x::AbstractDriver, is_offload::Bool=false) = true", DRIVER,
+           "a predicate stuck at one answer"),
+    Mutant("astunit_filename_swap",
+           "getMainFileName(x::AbstractASTUnit) = getOriginalSourceFileName(x)", ASTUNIT,
+           "two string accessors on one object wired to the same member",
+           """a unit whose main file and original source differ. Both are empty on a unit
+              that never parsed and both are the .cpp after a command-line parse, so the
+              two accessors agree in every state the suite can currently build. They
+              diverge only after ASTUnit::LoadFromASTFile, where the main file is the .ast
+              and the original source is the .cpp it came from -- and that entry point has
+              no wrapper. The load testset already writes an .ast and checks its magic, so
+              wrapping LoadFromASTFile is what closes this."""),
+    Mutant("astunit_fileid_swap",
+           "isInMainFileID(x::AbstractASTUnit, loc::SourceLocation) = isInPreambleFileID(x, loc)",
+           ASTUNIT,
+           "the main-file and preamble queries collapsed onto one another"),
+    Mutant("sm_next_offset_zero",
+           "getNextLocalOffset(src_mgr::SourceManager) = 0", SOURCEMGR,
+           "a monotonically growing counter swallowed"),
+    Mutant("sm_sloc_size_zero",
+           "local_sloc_entry_size(src_mgr::SourceManager) = 0", SOURCEMGR,
+           "the same, on the entry table's own size"),
+    Mutant("sm_created_fids_zero",
+           "getNumCreatedFIDsForFileID(src_mgr::SourceManager, id::FileID) = 0", SOURCEMGR,
+           "a per-key count answering zero whatever the key"),
+    Mutant("comment_command_id_zero",
+           "getCommandID(x::AbstractBlockCommandComment) = 0", COMMENT,
+           "a command-table index swallowed -- \\brief and \\param stop being distinguishable"),
+    Mutant("comment_param_index_zero",
+           "getParamIndex(x::AbstractParamCommandComment) = 0", COMMENT,
+           "an index ignored, so every \\param names the first parameter"),
+    Mutant("idtable_total_memory_zero",
+           "getTotalMemory(x::AbstractSelectorTable) = 0", IDTABLE,
+           "an allocator query swallowed"),
+    Mutant("cfg_synthetic_decls_zero",
+           "getNumSyntheticDeclStmts(x::AbstractCFG) = 0", CFGF,
+           "a whole-graph count swallowed"),
+    Mutant("cfg_cc_index_zero",
+           "getIndex(x::AbstractConstructionContext) = 0", CFGF,
+           "an argument position ignored, so every construction looks like the first"),
+    Mutant("pp_directives_zero",
+           "getNumDirectives(x::AbstractPreprocessor) = 0", LEX,
+           "a count of what the source actually contains, swallowed"),
+    Mutant("pp_total_memory_zero",
+           "getTotalMemory(x::AbstractPreprocessor) = 0", LEX,
+           "an allocator query swallowed"),
+    Mutant("sema_section_specifier_always",
+           "isValidSectionSpecifier(x::AbstractSema, s::AbstractString) = true", SEMA,
+           "a validator that accepts everything -- the shape of a swallowed diagnostic"),
+    Mutant("scope_prototype_depth_zero",
+           "getFunctionPrototypeDepth(x::AbstractScope) = 0", SEMA,
+           "a nesting depth pinned at the outermost value"),
+    Mutant("deduction_callarg_zero",
+           "getCallArgIndex(x::AbstractTemplateDeductionInfo) = 0", SEMA,
+           "the argument a deduction failed on, reported as always the first",
+           """a deduction that fails on an argument other than the first. CallArgIndex is
+              written only by the deduce-from-call-arguments path, and the three wrapped
+              DeduceTemplateArguments overloads are the two partial-specialisation ones and
+              the explicit-template-argument one -- none of which take call arguments, so
+              the field stays 0 in every state the suite can reach. Wrapping the
+              overload-resolution entry point (FunctionTemplateDecl + ArrayRef<Expr*>) is
+              what closes this."""),
+    Mutant("presumedloc_line_col_swap",
+           "getLine(x::PresumedLoc) = getColumn(x)", SRCLOC,
+           "line reported as column -- two integers off one struct, which `isa Integer` cannot separate"),
 ]
 
-"Run one mutant. Returns (:assertion, :crash, :survived)."
-function run_mutant(m::Mutant)
-    includes = join(["    try; include(\"$f\"); catch; end" for f in m.files], "\n")
+"""
+    run_files(files, mutation) -> String
+
+Include `files` in a fresh process, with `mutation` evaluated into ClangCompiler first when
+it is non-empty. Returns the combined output.
+"""
+function run_files(files, mutation)
+    includes = join(["    try; include(\"$f\"); catch; end" for f in files], "\n")
+    mutate = isempty(mutation) ? "" : "@eval ClangCompiler $mutation"
     prog = """
     using TestEnv; TestEnv.activate()
     cp("LocalPreferences.toml",
        joinpath(dirname(Base.active_project()), "LocalPreferences.toml"); force=true)
     using ClangCompiler
-    @eval ClangCompiler $(m.mutation)
+    $mutate
     $includes
     """
     out = IOBuffer()
     base = setenv(`$(Base.julia_cmd()) --project=$ROOT -e $prog`; dir=ROOT)
     run(pipeline(ignorestatus(base); stdout=out, stderr=out))
-    log = String(take!(out))
+    return String(take!(out))
+end
+
+"""
+    check_baseline(sel) -> Vector{String}
+
+The file sets that are already failing before any mutation, as human-readable lines.
+
+Detection here is "a `Test Failed` appeared", which cannot tell a mutant being caught from a
+suite that was red to begin with: a single broken assertion anywhere in a mutant's file set
+marks every mutant over that set as caught, and the score climbs while the suite gets worse.
+That is not hypothetical -- one wrong expected value in Lookup.jl once reported two genuine
+survivors as caught. So each distinct file set is run unmutated first, and a red one stops
+the run rather than inflating it.
+"""
+function check_baseline(sel)
+    bad = String[]
+    for files in unique(m.files for m in sel)
+        log = run_files(files, "")
+        if occursin("Test Failed", log) ||
+           occursin(r"signal|Segmentation|Assertion failed|SIGABRT", log)
+            push!(bad, join(files, ", "))
+        end
+    end
+    return bad
+end
+
+"Run one mutant. Returns (:assertion, :crash, :survived)."
+function run_mutant(m::Mutant)
+    log = run_files(m.files, m.mutation)
     occursin("Test Failed", log) && return :assertion
     occursin(r"signal|Segmentation|Assertion failed|SIGABRT", log) && return :crash
     return :survived
@@ -109,28 +252,63 @@ end
 function main(pattern="")
     sel = filter(m -> isempty(pattern) || occursin(pattern, m.label), CATALOGUE)
     isempty(sel) && (println("no mutants match \"$pattern\""); return 2)
+
+    println("checking the baseline is green before injecting anything")
+    red = check_baseline(sel)
+    if !isempty(red)
+        println("\nThese file sets FAIL before any mutation, so every mutant over them would")
+        println("be scored as caught for a reason that has nothing to do with the mutant:")
+        for r in red; println("  - $r"); end
+        println("\nFix the suite first; a score measured against a red tree only goes up.")
+        return 3
+    end
+
     println("running $(length(sel)) mutants\n")
-    survivors, lucky = String[], String[]
+    survivors, lucky, blocked, stale = String[], String[], String[], String[]
     for m in sel
         r = run_mutant(m)
-        mark = r === :assertion ? "caught  " : r === :crash ? "crash   " : "SURVIVED"
+        known = !isempty(m.blocked_on)
+        mark = r === :assertion ? "caught  " : r === :crash ? "crash   " :
+               known ? "blocked " : "SURVIVED"
         println("  $mark  $(m.label)")
-        r === :survived && push!(survivors, "$(m.label): $(m.note)")
-        r === :crash && push!(lucky, "$(m.label): $(m.note)")
+        if r === :survived
+            # one entry per mutant either way -- the score below counts these
+            if known
+                needs = replace(strip(m.blocked_on), r"\s*\n\s*" => " ")
+                push!(blocked, "$(m.label): $(m.note)\n      needs: $needs")
+            else
+                push!(survivors, "$(m.label): $(m.note)")
+            end
+        elseif r === :crash
+            push!(lucky, "$(m.label): $(m.note)")
+        elseif known
+            push!(stale, "$(m.label): now caught, so `blocked_on` is out of date -- drop it")
+        end
     end
-    score = round(100 * (length(sel) - length(survivors) - length(lucky)) / length(sel); digits=1)
+    # blocked mutants count against the score exactly like any other survivor: the gap is
+    # real whether or not it is expected, and an exemption that moved the number would be a
+    # way of not seeing it
+    caught = length(sel) - length(survivors) - length(blocked) - length(lucky)
+    score = round(100 * caught / length(sel); digits=1)
     println("\nmutation score (caught by an assertion): $score%")
     if !isempty(lucky)
         println("\nNoticed only because clang aborted, not because anything asserted --")
         println("a subtler version of the same fault would pass:")
         for l in lucky; println("  - $l"); end
     end
+    if !isempty(blocked)
+        println("\nKnown survivors. Each names the capability that would close it:")
+        for b in blocked; println("  - $b"); end
+    end
+    if !isempty(stale)
+        println("\nA known survivor is no longer surviving -- the exemption is stale:")
+        for s in stale; println("  - $s"); end
+    end
     if !isempty(survivors)
         println("\nSURVIVED. Some wrapper can return the wrong thing and nothing notices:")
         for s in survivors; println("  - $s"); end
-        return 1
     end
-    return 0
+    return (isempty(survivors) && isempty(stale)) ? 0 : 1
 end
 
 abspath(PROGRAM_FILE) == (@__FILE__) && exit(main(get(ARGS, 1, "")))

--- a/.claude/skills/suite-audit/mutants.jl
+++ b/.claude/skills/suite-audit/mutants.jl
@@ -39,6 +39,12 @@ end
 
 const ROOT = repo_root()
 
+# What "the fault was noticed by luck rather than detected" looks like in a log. Windows
+# reports an access violation instead of a signal, so leaving EXCEPTION out would let a
+# crashing baseline pass the gate there and be scored as green. Defined once because the two
+# call sites had already drifted apart; the triage grep in CLAUDE.md is the same set.
+const CRASH = r"signal|Segmentation|Assertion failed|SIGABRT|EXCEPTION"
+
 struct Mutant
     label::String
     mutation::String        # evaluated inside the ClangCompiler module
@@ -234,7 +240,7 @@ function check_baseline(sel)
     for files in unique(m.files for m in sel)
         log = run_files(files, "")
         if occursin("Test Failed", log) ||
-           occursin(r"signal|Segmentation|Assertion failed|SIGABRT", log)
+           occursin(CRASH, log)
             push!(bad, join(files, ", "))
         end
     end
@@ -245,7 +251,7 @@ end
 function run_mutant(m::Mutant)
     log = run_files(m.files, m.mutation)
     occursin("Test Failed", log) && return :assertion
-    occursin(r"signal|Segmentation|Assertion failed|SIGABRT", log) && return :crash
+    occursin(CRASH, log) && return :crash
     return :survived
 end
 

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -21,12 +21,21 @@ and the measurements for why each rule below earns its place.
   decided: a value, a round trip, or a relationship the shim could get wrong. (Whether
   carriers wrap at all is `test/abi.jl`'s job, not each test's.)
 - **When the value genuinely is not assertable, mark the site `# shape-only` with its reason.**
-  Three reasons are legitimate and no others: the host decides the value (triple, ABI,
-  mangling, path, size, alignment), it varies across the objects the test walks, or it is an
-  integer the target chooses. The marker belongs at the site — a baseline file recording the
-  same thing goes stale the moment a file is cleaned up and makes two branches conflict over a
-  generated artifact. The remaining markers are a ratchet, not a backlog: converting one
-  requires finding something Clang decided, which is not a mechanical edit.
+  Four reasons are legitimate and no others: the host decides the value (triple, ABI,
+  mangling, path, size, alignment), it varies across the objects the test walks, it is an
+  integer the target chooses, or nothing decides it because the read is of uninitialised
+  memory. That last one is not a softer version of the first — "the host decides it" says a
+  machine chose a real value, while "nothing decides it" says nobody wrote the memory, and
+  every site in the second class was once labelled with the first, which read as though
+  someone had checked. `tautologies.jl` rejects a marker whose text names none of them,
+  so the reason cannot decay back into decoration — but it checks only that a category was
+  *named*, never that the claim is true. `getLine` marked "the target chooses this value"
+  passes the linter and is still false, because a line number is decided by the source. Only
+  reading the site catches that, so write the reason you can defend. The marker belongs at the
+  site — a baseline file recording the same thing goes stale the moment a file is cleaned up
+  and makes two branches conflict over a generated artifact. The remaining markers are a
+  ratchet, not a backlog: converting one requires finding something Clang decided, which is
+  not a mechanical edit.
 - **Prefer an invariant that holds over any AST to a pinned value.** A pin catches drift away
   from today's answer but freezes the bug if today's answer has always been wrong; invariants
   (`test/clang/invariants.jl`) need no captured values and no per-platform care. They have
@@ -47,12 +56,19 @@ Only parsing and AST inspection can cross-target — the JIT still emits for the
 pinning downloads that target's GCC shard, so keep it to one target and one file rather than
 pinning at every site.
 
-**Nothing decides it** — module provenance (`isPartOfFramework`), a `Driver`'s LTO mode before
-argument processing, and a hand-built `Module`'s availability, including the `markUnavailable`
-transition whose gating predicate reads bits a synthetic module never had a module map to set.
-These read uninitialized memory. Pinning a triple does not help and would only make the answer
-look trustworthy; restate the precondition instead, or leave the site `# shape-only` with that
-as its reason. A wrapper whose value comes back outside its own enum (Julia prints
+**Nothing decides it** — module provenance (`isPartOfFramework`) and a hand-built `Module`'s
+availability, including the `markUnavailable` transition whose gating predicate reads bits a
+synthetic module never had a module map to set. These read uninitialized memory. Pinning a
+triple does not help and would only make the answer look trustworthy; restate the precondition
+instead, or leave the site `# shape-only` with that as its reason.
+
+Before accepting that, check whether the state can simply be *initialized*. A `Driver`'s LTO
+mode used to be the worked example here: asked of a driver that never processed arguments it
+is a read of uninitialized memory, and the site was marked accordingly. But `BuildCompilation`
+is what initializes it, so building one first turns the same call into an ordinary assertion —
+`-flto` gives true and `-fsyntax-only` gives false, which is a partition rather than a pin.
+Reaching for the marker is premature whenever a constructor or a setup call the test could
+make would give the field a value. A wrapper whose value comes back outside its own enum (Julia prints
 `<invalid #N>`) is this case — a UB precondition to restate, not a flaky test.
 
 **The host decides it, and neither of the above applies** — a sysroot, an executable path.

--- a/test/clang/api/AST/ASTContext.jl
+++ b/test/clang/api/AST/ASTContext.jl
@@ -232,7 +232,9 @@ using ClangCompiler: get_tag
     @test CC.getTypeSize(ctx, CC.getTypePtr(int_qt)) == 32   # AbstractType overload
     pt_qt = CC.getType(CC.VarDecl(getdecl("cta_pt_var")))
     @test CC.get_name(CC.getMemberPointerType(ctx, int_qt, pt_qt)) == "int CtaPt::*"   # QualType-class overload
-    @test CC.getScalableVectorType(ctx, int_qt, 4) isa CC.QualType   # null QualType off SVE/RVV targets
+    # scalable vectors exist only on AArch64 (SVE) and RISC-V (RVV), so this is a null
+    # QualType on some runners and a real one on others
+    @test CC.getScalableVectorType(ctx, int_qt, 4) isa CC.QualType  # shape-only: the target decides it
 
     # ---------- stmt-tree carriers: AtomicExpr / IndirectGotoStmt ----------
     nodes = CC.AbstractStmt[]
@@ -1012,8 +1014,8 @@ end
 
     # ---- getCXXABIKind / getDefaultOpenCLPointeeAddrSpace ----
     abi = CC.getCXXABIKind(ctx)
-    @test abi isa LX.CXTargetCXXABI_Kind  # shape-only: the host decides this
-    @test CC.getDefaultOpenCLPointeeAddrSpace(ctx) isa LX.CXLangAS  # shape-only: the host decides this
+    @test abi isa LX.CXTargetCXXABI_Kind  # shape-only: the target decides it (Itanium vs Microsoft)
+    @test CC.getDefaultOpenCLPointeeAddrSpace(ctx) isa LX.CXLangAS  # shape-only: the target decides it (address spaces follow the target's OpenCL support)
 
     # ---- getCurrentNamedModule: no C++20 named module is under construction here ----
     m = CC.getCurrentNamedModule(ctx)

--- a/test/clang/api/AST/Attr.jl
+++ b/test/clang/api/AST/Attr.jl
@@ -62,7 +62,8 @@ end
     @test !(CC.isInherited(dep))
     @test !CC.isPackExpansion(dep)
     @test !CC.is_null_handle(CC.getLocation(dep))
-    @test CC.getRange(dep) isa CC.SourceRange  # shape-only
+    @test CC.isValid((CC.getRange(dep)).begin_loc)
+    @test CC.isValid((CC.getRange(dep)).end_loc)
 
     # stamped predicates and casts: `isa<T>` beside `cast<T>`, and the cast names both
     # classes when it refuses rather than handing back a carrier over nothing

--- a/test/clang/api/AST/Comment.jl
+++ b/test/clang/api/AST/Comment.jl
@@ -41,7 +41,8 @@ using Test
     @test fc isa CC.FullComment
     if fc.ptr != C_NULL
         @test CC.getCommentKindName(fc) == "FullComment"
-        @test CC.getSourceRange(fc) isa CC.SourceRange  # shape-only
+        @test CC.isValid((CC.getSourceRange(fc)).begin_loc)
+        @test CC.isValid((CC.getSourceRange(fc)).end_loc)
         n = CC.child_count(fc)
         @test n isa Integer
         @test n >= 0
@@ -54,7 +55,7 @@ using Test
             for j = 0:(CC.child_count(c) - 1)
                 gc = CC.getChild(c, j)
                 tc = CC.TextComment(gc)
-                tc.ptr != C_NULL && @test CC.getText(tc) isa String  # shape-only
+                tc.ptr != C_NULL && @test !isempty(CC.getText(tc))
             end
             bcc = CC.BlockCommandComment(c)
             if bcc.ptr != C_NULL
@@ -99,6 +100,9 @@ end
         @test !CC.is_null_handle(CC.getEndLoc(fc))
         @test !CC.is_null_handle(CC.getLocation(fc))
 
+        dirs = Bool[]
+        cmds = Tuple{String,Int}[]
+        pidx = Int[]
         for i = 0:(CC.child_count(fc) - 1)
             c = CC.getChild(fc, i)
             @test !CC.is_null_handle(CC.getBeginLoc(c))
@@ -115,7 +119,7 @@ end
 
             bcc = CC.BlockCommandComment(c)
             if bcc.ptr != C_NULL
-                @test CC.getCommandID(bcc) isa Integer  # shape-only: the target chooses this value
+                push!(cmds, (CC.getCommandName(bcc, ctx), Int(CC.getCommandID(bcc))))
                 @test !CC.is_null_handle(CC.getCommandNameBeginLoc(bcc))
                 @test CC.getCommandMarker(bcc) isa Enum
                 @test CC.hasNonWhitespaceParagraph(bcc)
@@ -123,25 +127,49 @@ end
                 @test n isa Integer
                 for k = 0:(n - 1)
                     @test !isempty(CC.getArgText(bcc, k))
-                    @test CC.getArgRange(bcc, k) isa CC.SourceRange  # shape-only
+                    @test CC.isValid((CC.getArgRange(bcc, k)).begin_loc)
+                    @test CC.isValid((CC.getArgRange(bcc, k)).end_loc)
                 end
                 para = CC.getParagraph(bcc)
                 @test para isa CC.ParagraphComment
-                para.ptr != C_NULL && @test CC.isWhitespace(para) isa Bool  # shape-only
+                # `hasNonWhitespaceParagraph` was just asserted, so this paragraph is the
+                # non-whitespace one -- the two accessors have to agree
+                para.ptr != C_NULL && @test !CC.isWhitespace(para)
             end
 
             pcc = CC.ParamCommandComment(c)
             if pcc.ptr != C_NULL
                 @test CC.getDirection(pcc) isa Enum
-                @test CC.isDirectionExplicit(pcc) isa Bool  # shape-only
+                push!(dirs, CC.isDirectionExplicit(pcc))
                 @test CC.isParamIndexValid(pcc)
                 @test !(CC.isVarArgParam(pcc))
-                CC.hasParamName(pcc) && @test CC.getParamNameRange(pcc) isa CC.SourceRange  # shape-only
+                CC.hasParamName(pcc) && @test CC.isValid((CC.getParamNameRange(pcc)).begin_loc)
+                CC.hasParamName(pcc) && @test CC.isValid((CC.getParamNameRange(pcc)).end_loc)
                 if CC.isParamIndexValid(pcc) && !CC.isVarArgParam(pcc)
-                    @test CC.getParamIndex(pcc) isa Integer  # shape-only: the target chooses this value
+                    push!(pidx, Int(CC.getParamIndex(pcc)))
                 end
             end
         end
+        # `\param a` is written with no direction and `\param[out] b` with one, so this
+        # source puts one comment on each side. A predicate reading a neighbouring bit --
+        # or the direction enum itself, which is set either way -- is constant here.
+        @test sort(dirs) == [false, true]
+
+        # The command ID indexes clang's CommandTraits table, so its numeric value moves
+        # with the clang release and pinning it would break on the next one. What does not
+        # move is that the ID and the name agree: this source writes \brief, \param twice
+        # and \return, so three distinct names carry three distinct IDs and the repeated
+        # name repeats its own. A swallowed ID collapses that to one and fails here.
+        @test length(cmds) == 4
+        @test length(unique(last.(cmds))) == length(unique(first.(cmds))) == 3
+        @test allunique(unique(cmds))
+        for (n1, i1) in cmds, (n2, i2) in cmds
+            @test (n1 == n2) == (i1 == i2)
+        end
+
+        # `\param a` and `\param[out] b` name the first and second parameters of
+        # `cc_doc_add3(int a, int b)`. An accessor ignoring its subject reports 0 twice.
+        @test sort(pidx) == [0, 1]
     end
 
     CC.dispose(f)
@@ -187,6 +215,7 @@ end
         @test !isempty(nodes)
 
         inline_names = String[]
+        inline_cmds = Tuple{String,Int}[]
         tag_names = String[]
         attr_names = String[]
         tparam_names = String[]
@@ -194,21 +223,24 @@ end
         for c in nodes
             icc = CC.InlineCommandComment(c)
             if icc.ptr != C_NULL
-                @test CC.getCommandID(icc) isa Integer  # shape-only: the target chooses this value
-                @test CC.getCommandNameRange(icc) isa CC.SourceRange  # shape-only
+                push!(inline_cmds, (CC.getCommandName(icc, ctx), Int(CC.getCommandID(icc))))
+                @test CC.isValid((CC.getCommandNameRange(icc)).begin_loc)
+                @test CC.isValid((CC.getCommandNameRange(icc)).end_loc)
                 @test CC.getRenderKind(icc) isa Enum
                 push!(inline_names, CC.getCommandName(icc, ctx))
                 na = CC.getNumArgs(icc)
                 @test na isa Integer
                 for k = 0:(na - 1)
                     @test !isempty(CC.getArgText(icc, k))
-                    @test CC.getArgRange(icc, k) isa CC.SourceRange  # shape-only
+                    @test CC.isValid((CC.getArgRange(icc, k)).begin_loc)
+                    @test CC.isValid((CC.getArgRange(icc, k)).end_loc)
                 end
             end
 
             hst = CC.HTMLStartTagComment(c)
             if hst.ptr != C_NULL
-                @test CC.getTagNameSourceRange(hst) isa CC.SourceRange  # shape-only
+                @test CC.isValid((CC.getTagNameSourceRange(hst)).begin_loc)
+                @test CC.isValid((CC.getTagNameSourceRange(hst)).end_loc)
                 @test !(CC.isMalformed(hst))
                 @test !(CC.isSelfClosing(hst))
                 push!(tag_names, CC.getTagName(hst))
@@ -232,7 +264,8 @@ end
                 @test CC.isPositionValid(tpc)
                 if CC.hasParamName(tpc)
                     push!(tparam_names, CC.getParamNameAsWritten(tpc))
-                    @test CC.getParamNameRange(tpc) isa CC.SourceRange  # shape-only
+                    @test CC.isValid((CC.getParamNameRange(tpc)).begin_loc)
+                    @test CC.isValid((CC.getParamNameRange(tpc)).end_loc)
                 end
                 # `T` is the sole parameter of the sole template parameter list of
                 # cc_doc_rich, so Sema resolves the \tparam to position {0} and the
@@ -242,14 +275,17 @@ end
                 @test dep isa Integer
                 @test dep > 0
                 @test dep == 1
-                for k = 0:(dep - 1)
-                    @test CC.getIndex(tpc, k) isa Integer  # shape-only: the target chooses this value
-                end
                 @test CC.getIndex(tpc, 0) == 0
             end
         end
 
         @test "c" in inline_names
+        # same agreement as the block commands: the table index is not pinnable across
+        # clang releases, but a name and its ID have to identify each other
+        @test !isempty(inline_cmds)
+        for (n1, i1) in inline_cmds, (n2, i2) in inline_cmds
+            @test (n1 == n2) == (i1 == i2)
+        end
         @test "b" in tag_names
         @test n_end_tags == 1
         @test attr_names == ["class"]
@@ -337,7 +373,8 @@ end
         param_names = String[]
         for c in collect_nodes(fc)
             bcc = CC.BlockCommandComment(c)
-            bcc.ptr != C_NULL && @test CC.getCommandNameRange(bcc, ctx) isa CC.SourceRange  # shape-only
+            bcc.ptr != C_NULL && @test CC.isValid((CC.getCommandNameRange(bcc, ctx)).begin_loc)
+            bcc.ptr != C_NULL && @test CC.isValid((CC.getCommandNameRange(bcc, ctx)).end_loc)
 
             vbc = CC.VerbatimBlockComment(c)
             if vbc.ptr != C_NULL
@@ -355,7 +392,8 @@ end
             vlc = CC.VerbatimLineComment(c)
             if vlc.ptr != C_NULL
                 push!(verbatim_lines, CC.getText(vlc))
-                @test CC.getTextRange(vlc) isa CC.SourceRange  # shape-only
+                @test CC.isValid((CC.getTextRange(vlc)).begin_loc)
+                @test CC.isValid((CC.getTextRange(vlc)).end_loc)
             end
 
             pcc = CC.ParamCommandComment(c)
@@ -390,7 +428,8 @@ end
             if hst.ptr != C_NULL
                 for k = 0:(CC.getNumAttrs(hst) - 1)
                     n_attrs += 1
-                    @test CC.getAttrNameRange(hst, k) isa CC.SourceRange  # shape-only
+                    @test CC.isValid((CC.getAttrNameRange(hst, k)).begin_loc)
+                    @test CC.isValid((CC.getAttrNameRange(hst, k)).end_loc)
                     @test !CC.is_null_handle(CC.getAttrNameLocEnd(hst, k))
                 end
             end

--- a/test/clang/api/AST/DeclBase.jl
+++ b/test/clang/api/AST/DeclBase.jl
@@ -14,7 +14,8 @@ using Test
     g = CC.resolve(nd)
 
     # source range / location
-    @test CC.getSourceRange(g) isa CC.SourceRange  # shape-only
+    @test CC.isValid((CC.getSourceRange(g)).begin_loc)
+    @test CC.isValid((CC.getSourceRange(g)).end_loc)
     @test !CC.is_null_handle(CC.getBodyRBrace(g))
 
     # flags
@@ -61,7 +62,7 @@ using Test
     @test length(CC.getRedecls(g)) == n
 
     # attributes: none written, so the kind-indexed queries answer negatively
-    @test CC.getMaxAlignment(g) isa Integer  # shape-only: the host decides this
+    @test Int(CC.getMaxAlignment(g)) == 0
     @test CC.hasAttrOfKind(g, CC.LibClangEx.CXAttrKind_Deprecated) == false
     @test CC.getAttrOfKind(g, CC.LibClangEx.CXAttrKind_Deprecated).ptr == C_NULL
     @test CC.hasDefiningAttr(g) == false
@@ -118,11 +119,17 @@ using Test
 
     # DeclarationNameInfo: owned box, mutated and read back
     ni = CC.DeclarationNameInfo(name, CC.getLocation(nd))
-    @test CC.getSourceRange(ni) isa CC.SourceRange  # shape-only
+    @test CC.isValid((CC.getSourceRange(ni)).begin_loc)
+    @test CC.isValid((CC.getSourceRange(ni)).end_loc)
     @test CC.isInstantiationDependent(ni) == false
     @test CC.containsUnexpandedParameterPack(ni) == false
     @test CC.getNamedTypeInfo(ni).ptr == C_NULL
-    @test CC.getCXXOperatorNameRange(ni) isa CC.SourceRange  # shape-only
+    # `ni` was built over an ordinary identifier, so the two name-kind-specific slots are
+    # the defaults clang leaves them at -- the operator range invalid and the literal
+    # operator location null. Asserting the range is *invalid* is what separates this
+    # accessor from one reading the name's own range, which is valid.
+    @test !CC.isValid((CC.getCXXOperatorNameRange(ni)).begin_loc)
+    @test !CC.isValid((CC.getCXXOperatorNameRange(ni)).end_loc)
     @test CC.is_null_handle(CC.getCXXLiteralOperatorNameLoc(ni))
     CC.setName(ni, name)
     CC.setLoc(ni, CC.getLocation(nd))

--- a/test/clang/api/AST/Expr.jl
+++ b/test/clang/api/AST/Expr.jl
@@ -1032,8 +1032,12 @@ end
     @test CC.getSyntacticForm(poe).ptr != C_NULL
     @test CC.getNumSemanticExprs(poe) >= 1
     @test 0 <= CC.getResultExprIndex(poe) < CC.getNumSemanticExprs(poe)
-    @test CC.getResultExpr(poe) isa CC.Expr_        # property read has a result
     @test CC.getResultExpr(poe).ptr != C_NULL
+    # the result is the semantic expression the result index names. That relationship is
+    # what ties the two accessors together; `isa Expr_` holds even if one of them reads
+    # the syntactic form or an adjacent slot.
+    @test CC.getResultExpr(poe).ptr ==
+          CC.getSemanticExpr(poe, CC.getResultExprIndex(poe)).ptr
     @test !CC.is_null_handle(CC.getSemanticExpr(poe, 0))
     @test CC.getSemanticExpr(poe, 0).ptr != C_NULL
 
@@ -1202,8 +1206,12 @@ end
     # ---- FullExpr / ConstantExpr (immediate consteval invocation) ----
     cst = pick(CC.ConstantExpr)
     @test cst isa CC.ConstantExpr
-    @test CC.getSubExpr(cst) isa CC.Expr_            # FullExpr::getSubExpr
     @test CC.getSubExpr(cst).ptr != C_NULL
+    # a FullExpr wraps exactly one sub-expression, so `FullExpr::getSubExpr` and the child
+    # walk are two readings of the same edge and must agree
+    cst_kids = collect(CC.children(cst))
+    @test length(cst_kids) == 1
+    @test CC.getSubExpr(cst).ptr == cst_kids[1].ptr
     @test CC.getResultStorageKind(cst) isa CC.LibClangEx.CXConstantResultStorageKind
     @test CC.getResultAPValueKind(cst) isa CC.LibClangEx.CXAPValueKind
     # hasAPValueResult is defined upstream as "APValueKind != None"

--- a/test/clang/api/AST/ExprCXX.jl
+++ b/test/clang/api/AST/ExprCXX.jl
@@ -1762,7 +1762,10 @@ end
     @test CC.getAsString(ni) == "ll_oo"
     @test CC.getLoc(ni).ptr == CC.getNameLoc(ule).ptr
     dispose(ni)
-    @test CC.getQualifierRange(ule) isa CC.SourceRange   # `ll_oo` is unqualified
+    # `ll_oo` is written without a `T::`, so the qualifier range is the invalid one clang
+    # default-constructs -- a shim handing back the whole expression's range instead would
+    # satisfy `isa SourceRange` and fail this
+    @test !CC.isValid(CC.getQualifierRange(ule).begin_loc)
 
     # ---- DependentScopeDeclRefExpr: the `T::` is always written -------------------
     dre = _find_node(CC.DependentScopeDeclRefExpr, tpl_body("ll_dref"))
@@ -1804,7 +1807,8 @@ end
     ms_body = CC.resolve(CC.getBody(CC.FunctionDecl(get_decl(fms))))
     mp = _find_node(CC.MSPropertyRefExpr, ms_body)
     @test mp isa CC.MSPropertyRefExpr
-    @test CC.getQualifierRange(mp) isa CC.SourceRange   # `p->x` is unqualified
+    # `p->x` names no `T::`, so the qualifier range is the invalid default
+    @test !CC.isValid(CC.getQualifierRange(mp).begin_loc)
 
     dispose(fms)
     dispose(Ims)
@@ -2468,7 +2472,9 @@ end
     @test pre isa CC.NestedNameSpecifierLoc
     @test CC.hasQualifier(pre) == false
     @test CC.getNestedNameSpecifier(pre).ptr == C_NULL
-    @test CC.getSourceRange(pre) isa CC.SourceRange   # an empty box is a legal value
+    # an empty prefix carries no location either, so the box is the invalid one -- the
+    # value that makes it a legal result rather than merely a well-typed one
+    @test !CC.isValid(CC.getSourceRange(pre).begin_loc)
     CC.dispose(pre)
 
     # getTypeLoc is defined only for the two type-naming kinds, and which kind clang records

--- a/test/clang/api/AST/RecordLayout.jl
+++ b/test/clang/api/AST/RecordLayout.jl
@@ -84,7 +84,7 @@ end
     # vbptr is an MS-ABI construct; on Itanium the queries answer false with a
     # negative sentinel offset — assert shape, not ABI specifics
     @test !(CC.hasVBPtr(virt))
-    @test CC.getVBPtrOffset(virt) isa Integer  # shape-only: the target chooses this value
+    @test CC.getVBPtrOffset(virt) isa Integer  # shape-only: the target ABI decides it — a real offset under MS, a negative sentinel under Itanium
     @test CC.getNonVirtualSize(virt) <= CC.getSize(virt)
 
     dispose(f)

--- a/test/clang/api/AST/Stmt.jl
+++ b/test/clang/api/AST/Stmt.jl
@@ -1819,7 +1819,9 @@ end
         @test op_r isa CC.SourceRange
         @test !CC.is_null_handle(op_r.begin_loc)
         @test !CC.is_null_handle(op_r.end_loc)
-        @test CC.getModifier(ops[1]) isa Char    # '\0' when the reference carries none
+        # `%0` carries no modifier letter, so clang reports the NUL it uses for "none" --
+        # the value that separates this accessor from one reading an adjacent byte
+        @test CC.getModifier(ops[1]) == '\0'
         for p in pieces
             dispose(p)
         end

--- a/test/clang/api/AST/StmtCXX.jl
+++ b/test/clang/api/AST/StmtCXX.jl
@@ -33,8 +33,15 @@ using Test
         @test CC.getInit(frs) isa CC.AbstractStmt
         @test !CC.is_null_handle(CC.getRangeStmt(frs))
         @test !CC.is_null_handle(CC.getLoopVarStmt(frs))
-        @test CC.getCond(frs) isa CC.Expr_   # implicit __begin != __end
-        @test CC.getInc(frs) isa CC.Expr_    # implicit ++__begin
+        # the condition and increment clang synthesises are `__begin != __end` and
+        # `++__begin`; asserting their operators is what separates the two accessors,
+        # which `isa Expr_` cannot do because both wrappers return one
+        cond = CC.resolve(CC.getCond(frs))
+        @test cond isa CC.AbstractBinaryOperator
+        @test CC.getOpcode(cond) == CC.LibClangEx.CXBinaryOperatorKind_BO_NE
+        inc = CC.resolve(CC.getInc(frs))
+        @test inc isa CC.AbstractUnaryOperator
+        @test CC.getOpcode(inc) == CC.LibClangEx.CXUnaryOperatorKind_UO_PreInc
     end
     dispose(I)
 
@@ -125,8 +132,11 @@ end
     # the ParagraphComment refinement wherever it applies. Returns the paragraph count.
     function walk_comment(c, n)
         c.ptr == C_NULL && return n
-        @test CC.isInlineContentComment(c) isa Bool  # shape-only
-        @test CC.isBlockContentComment(c) isa Bool  # shape-only
+        # InlineContentComment and BlockContentComment are disjoint branches of the
+        # Comment hierarchy, so no node is both. Two predicates wired to the same
+        # underlying query -- the way a copy-paste slip in the shim reads -- would be
+        # equal instead, and both true on every content node.
+        @test !(CC.isInlineContentComment(c) && CC.isBlockContentComment(c))
         @test !(CC.isHTMLTagComment(c))
         pc = CC.ParagraphComment(c)
         if pc.ptr != C_NULL
@@ -325,8 +335,10 @@ end
         n = CC.getNumChildrenExclBody(cbs)
         @test n isa Integer
         @test n > 0
+        body = CC.getBody(cbs)
         for i = 0:(Int(n) - 1)
-            @test CC.getChildExclBody(cbs, i) isa CC.Stmt  # shape-only
+            # what "ExclBody" means: the body is the one child this view never yields
+            @test CC.getChildExclBody(cbs, i).ptr != body.ptr
         end
         # The coroutine body is slot 0 of the full child list and the promise
         # declaration slot 1, so the body-excluded view starts at the promise.
@@ -349,11 +361,14 @@ end
     mses = collect_stmts(CC.MSDependentExistsStmt, CC.resolve(CC.getBody(mfd)),
                          CC.MSDependentExistsStmt[])
     @test length(mses) == 2
+    # the source writes one `__if_exists` and one `__if_not_exists`, so the predicate has
+    # to separate them; one wired to a constant or to the wrong bit gives 0 or 2
+    @test count(CC.isIfExists, mses) == 1
     for m in mses
         @test !CC.is_null_handle(CC.getKeywordLoc(m))
-        @test CC.isIfExists(m) isa Bool  # shape-only
         @test CC.isIfNotExists(m) == !CC.isIfExists(m)
-        @test CC.getQualifierRange(m) isa CC.SourceRange  # shape-only
+        @test CC.isValid((CC.getQualifierRange(m)).begin_loc)
+        @test CC.isValid((CC.getQualifierRange(m)).end_loc)
         @test !CC.is_null_handle(CC.getQualifier(m))
         @test CC.getSubStmt(m) isa CC.CompoundStmt
         @test CC.getSubStmt(m).ptr != C_NULL

--- a/test/clang/api/AST/TemplateName.jl
+++ b/test/clang/api/AST/TemplateName.jl
@@ -61,7 +61,8 @@ end
     @test CC.getKind(qarg) == CC.LibClangEx.CXTemplateArgument_Template
     tn_q = CC.getAsTemplate(qarg)
     @test CC.getKind(tn_q) == CC.LibClangEx.CXTemplateName_QualifiedTemplate
-    @test CC.getDependence(tn_q) isa Integer  # shape-only: the target chooses this value
+    # `TnNS::TnBox` names a concrete template, so nothing about it is dependent
+    @test Int(CC.getDependence(tn_q)) == 0
     @test occursin("TnBox", CC.getAsString(tn_q, ctx))
     @test occursin("TnBox", CC.getAsString(tn_q, ctx, CC.LibClangEx.CXTemplateName_Qualified_None))
     @test occursin("TnBox", CC.getAsString(tn_q, ctx, CC.LibClangEx.CXTemplateName_Qualified_Fully))
@@ -98,7 +99,8 @@ end
     sub = CC.getAsSubstTemplateTemplateParm(tn_s)
     @test sub isa CC.SubstTemplateTemplateParmStorage
     @test sub.ptr != C_NULL
-    @test CC.getIndex(sub) isa Integer  # shape-only: the target chooses this value
+    # the substitution stands in for the first (and only) template template parameter
+    @test Int(CC.getIndex(sub)) == 0
     @test !CC.is_null_handle(CC.getAssociatedDecl(sub))
     repl = CC.getReplacement(sub)
     @test repl isa CC.TemplateName

--- a/test/clang/api/AST/TypeLoc.jl
+++ b/test/clang/api/AST/TypeLoc.jl
@@ -54,7 +54,11 @@ end
     ptl = CC.resolve(tl)
     @test ptl isa CC.PointerTypeLoc
     @test CC.isValid(CC.getStarLoc(ptl))
-    @test CC.getSourceRange(ptl) isa CC.SourceRange    # base method on a carrier
+    # the base method reached through a carrier still has to return this declarator's own
+    # written extent; a default-constructed range would satisfy `isa SourceRange`
+    ptl_rng = CC.getSourceRange(ptl)
+    @test CC.isValid(ptl_rng.begin_loc)
+    @test CC.isValid(ptl_rng.end_loc)
     # a pointer location is no array location, and the cast names both classes rather than
     # handing back a box over nothing — nothing to dispose on the failing path
     @test_throws CC.CastError CC.ArrayTypeLoc(ptl)
@@ -220,7 +224,8 @@ end
     @test tl isa CC.TypeLoc
     @test !CC.isNull(tl)
     @test CC.resolve(CC.getTypePtr(CC.getType(tl))) isa CC.PointerType
-    @test CC.getSourceRange(tl) isa CC.SourceRange  # shape-only
+    @test CC.isValid((CC.getSourceRange(tl)).begin_loc)
+    @test CC.isValid((CC.getSourceRange(tl)).end_loc)
     @test !CC.is_null_handle(CC.getBeginLoc(tl))
 
     nxt = CC.getNextTypeLoc(tl)                     # the pointee (int) loc; owned box

--- a/test/clang/api/Analysis/CFG.jl
+++ b/test/clang/api/Analysis/CFG.jl
@@ -164,7 +164,7 @@ end
         try
             # CFG tail: try-dispatch blocks and the synthetic-DeclStmt map
             @test CC.getNumTryBlocks(cfg) == 0
-            @test CC.getNumSyntheticDeclStmts(cfg) isa Integer  # shape-only: the target chooses this value
+            @test Int(CC.getNumSyntheticDeclStmts(cfg)) == 0
 
             entry = CC.getEntry(cfg)
             exit_ = CC.getExit(cfg)
@@ -661,8 +661,10 @@ end
                     @test length(fp) == Int(CC.getNumFilteredPreds(b))
                     @test length(fs) <= Int(CC.succ_size(b))
                     @test length(fp) <= Int(CC.pred_size(b))
-                    # non-default FilterOptions still return a well-formed count
-                    @test CC.getNumFilteredSuccs(b, false, false) isa Integer  # shape-only
+                    # with both filters off nothing is dropped, so the filtered count
+                    # collapses onto the unfiltered one -- the relationship that pins the
+                    # options to an effect rather than merely returning some integer
+                    @test Int(CC.getNumFilteredSuccs(b, false, false)) == Int(CC.succ_size(b))
                 end
 
                 # a successor walk filters nothing here: its source block is never null
@@ -696,12 +698,14 @@ end
             };
             CfgCCObj cfg_cc_make(int x);
             void cfg_cc_take(CfgCCObj o);
+            void cfg_cc_take2(int a, CfgCCObj o);
             CfgCCObj cfg_cc_fn(int x) {
                 CfgCCObj local(x);
                 CfgCCObj made = cfg_cc_make(x);
                 CfgCCObj *heap = new CfgCCObj(x);
                 cfg_cc_take(CfgCCObj(x));
-                auto lam = [local]() { return local.v; };
+                cfg_cc_take2(x, CfgCCObj(x));
+                auto lam = [local, made]() { return local.v + made.v; };
                 delete heap;
                 return local;
             }
@@ -734,6 +738,8 @@ end
                 typed_call = nothing
                 seen = K.CXConstructionContextKind[]
                 elided = CC.ConstructionContext[]
+                bind_temp = Bool[]
+                cc_index = Tuple{Symbol,Int}[]
                 for i in 0:(n - 1)
                     b = CC.getBlock(cfg, i)
                     for j in 0:(Int(CC.size(b)) - 1)
@@ -754,20 +760,37 @@ end
                         ck = CC.getKind(cc)
                         @test ck isa K.CXConstructionContextKind
                         push!(seen, ck)
-                        # every payload accessor is total: it answers a carrier of its
-                        # own type, NULL-valued unless the kind matches
-                        @test CC.getDeclStmt(cc) isa CC.DeclStmt  # shape-only
+                        # Every payload accessor is total: it answers a carrier of its own
+                        # type, NULL-valued unless the kind matches. `isa` states only the
+                        # first half, and states it for every accessor at once, so it
+                        # cannot tell one wired to its own slot from one wired to a
+                        # sibling's. The biconditional below is the second half -- non-null
+                        # for exactly the kinds that carry that payload -- and a
+                        # sibling-wired accessor is non-null under the wrong kind.
+                        @test (CC.getDeclStmt(cc).ptr != C_NULL) ==
+                              (ck in (K.CXConstructionContextKind_SimpleVariableKind,
+                                      K.CXConstructionContextKind_CXX17ElidedCopyVariableKind))
                         @test CC.is_null_handle(CC.getCXXCtorInitializer(cc))
-                        @test CC.getCXXNewExpr(cc) isa CC.CXXNewExpr  # shape-only
-                        @test CC.getCXXBindTemporaryExpr(cc) isa CC.CXXBindTemporaryExpr  # shape-only
+                        @test (CC.getCXXNewExpr(cc).ptr != C_NULL) ==
+                              (ck == K.CXConstructionContextKind_NewAllocatedObjectKind)
+                        # this one is not a function of the kind: it is present when the
+                        # construction binds a temporary needing destruction, which is a
+                        # property of the individual construction rather than its class.
+                        # Collected and asserted as a partition below.
+                        push!(bind_temp, CC.getCXXBindTemporaryExpr(cc).ptr != C_NULL)
                         @test CC.is_null_handle(CC.getMaterializedTemporaryExpr(cc))
                         @test CC.is_null_handle(CC.getConstructorAfterElision(cc))
                         @test CC.is_null_handle(CC.getConstructionContextAfterElision(cc))
-                        @test CC.getReturnStmt(cc) isa CC.ReturnStmt
-                        @test CC.getCallLikeExpr(cc) isa CC.Expr_  # shape-only
-                        @test CC.getLambdaExpr(cc) isa CC.LambdaExpr  # shape-only
-                        @test CC.getInitializer(cc) isa CC.Expr_  # shape-only
-                        @test CC.getFieldDecl(cc) isa CC.FieldDecl  # shape-only
+                        @test (CC.getReturnStmt(cc).ptr != C_NULL) ==
+                              (ck in (K.CXConstructionContextKind_SimpleReturnedValueKind,
+                                      K.CXConstructionContextKind_CXX17ElidedCopyReturnedValueKind))
+                        @test (CC.getCallLikeExpr(cc).ptr != C_NULL) ==
+                              (ck == K.CXConstructionContextKind_ArgumentKind)
+                        # the three lambda-capture payloads travel together
+                        for get in (CC.getLambdaExpr, CC.getInitializer, CC.getFieldDecl)
+                            @test (get(cc).ptr != C_NULL) ==
+                                  (ck == K.CXConstructionContextKind_LambdaCaptureKind)
+                        end
                         if ck == K.CXConstructionContextKind_SimpleVariableKind ||
                            ck == K.CXConstructionContextKind_CXX17ElidedCopyVariableKind
                             @test CC.getDeclStmt(cc).ptr != C_NULL
@@ -785,10 +808,10 @@ end
                             @test CC.getReturnStmt(cc).ptr != C_NULL
                         elseif ck == K.CXConstructionContextKind_ArgumentKind
                             @test CC.getCallLikeExpr(cc).ptr != C_NULL
-                            @test CC.getIndex(cc) isa Integer  # shape-only: the target chooses this value
+                            push!(cc_index, (:arg, Int(CC.getIndex(cc))))
                         elseif ck == K.CXConstructionContextKind_LambdaCaptureKind
                             @test CC.getLambdaExpr(cc).ptr != C_NULL
-                            @test CC.getIndex(cc) isa Integer  # shape-only: the target chooses this value
+                            push!(cc_index, (:capture, Int(CC.getIndex(cc))))
                             @test CC.getInitializer(cc).ptr != C_NULL
                             @test CC.getFieldDecl(cc).ptr != C_NULL
                         end
@@ -797,6 +820,20 @@ end
                 # `CfgCCObj local(x);` is a direct-initialised local of class type, so the
                 # rich builder always yields a variable-kind Constructor element for it
                 @test !isempty(seen)
+                # Both polarities occur over this source, so the accessor separates the
+                # constructions that bind a temporary from the ones that do not. A shim
+                # swallowing its result is all-false here and one wired to a sibling
+                # payload is all-true; only a working one partitions the set.
+                @test any(bind_temp)
+                @test !all(bind_temp)
+                # cfg_cc_take2 takes its object second and the lambda captures two, so both
+                # accessors have a position other than 0 to report. Without that the source
+                # only ever constructs at index 0 and an accessor ignoring its subject is
+                # indistinguishable from a working one.
+                @test (:arg, 0) in cc_index
+                @test (:arg, 1) in cc_index
+                @test (:capture, 0) in cc_index
+                @test (:capture, 1) in cc_index
                 # Under C++17 the temporary in a copy-initialisation is not merely elided
                 # but never materialised, so no element carries an elided-temporary
                 # context here and the two after-elision accessors have nothing to read.

--- a/test/clang/api/Basic/IdentifierTable.jl
+++ b/test/clang/api/Basic/IdentifierTable.jl
@@ -28,9 +28,9 @@ using Test
     @test CC.isImplicitIntRequired(lo) == false
     @test CC.isImplicitIntAllowed(lo) == false
     @test !(CC.hasSjLjExceptions(lo))
-    # target-decided: structured exception handling is a Windows construct, so the
-    # default this LangOptions carries depends on the runner
-    @test CC.hasSEHExceptions(lo) isa Bool  # shape-only: the host decides this
+    # structured exception handling is a Windows construct, so the default this
+    # LangOptions carries follows the target the interpreter was built for
+    @test CC.hasSEHExceptions(lo) isa Bool  # shape-only: the target decides it
     @test !(CC.hasDWARFExceptions(lo))
     @test !(CC.hasWasmExceptions(lo))
     @test CC.isSYCL(lo) == false
@@ -106,16 +106,16 @@ using Test
     @test CC.isImplicitGlobalModule(root) == false
     @test CC.isPrivateModule(root) == false
     # last of the synthetic-module bits: a module built without a module map has no
-    # unimportable reason recorded either, so the answer is the runner's, not clang's
-    @test CC.isUnimportable(root) isa Bool  # shape-only: the host decides this
-    # A synthetic module has no module map, so isAvailable reads bits that were never
-    # set and the answer differs per runner (CLAUDE.md records this); only the shape
-    # of it is assertable here.
-    @test CC.isAvailable(root) isa Bool  # shape-only: the host decides this
+    # unimportable reason recorded either, so there is nothing to read back
+    @test CC.isUnimportable(root) isa Bool  # shape-only: nothing decides it — never set on a module built without a module map
+    # A synthetic module has no module map, so isAvailable reads bits nothing ever set.
+    # The value is not the host's answer to a question -- there is no answer, which is
+    # why only the shape is asserted (CLAUDE.md records this class).
+    @test CC.isAvailable(root) isa Bool  # shape-only: nothing decides it — reads bits never set on a synthetic module
     @test CC.isSubModule(root) == false
-    # framework membership walks to the top-level module and depends on how the
-    # host's module map was synthesized — assert the shape, not the value
-    @test CC.isPartOfFramework(root) isa Bool  # shape-only: the host decides this
+    # framework membership walks to the top-level module, whose framework bits a
+    # synthetic module never had a module map to set — assert the shape, not the value
+    @test CC.isPartOfFramework(root) isa Bool  # shape-only: nothing decides it — walks to a top-level module whose framework bits were never set
     @test CC.isSubFramework(root) == false
     @test CC.isModulePartition(root) == false
     @test CC.isModuleImplementation(root) == false
@@ -391,7 +391,8 @@ end
     @test CC.getNameForSlot(multi, 0) == "width"
     @test CC.getNameForSlot(multi, 1) == "height"
     @test CC.getSelector(selt, 2, [width, height]).ptr == multi.ptr
-    @test CC.getTotalMemory(selt) isa Integer  # shape-only: the target chooses this value
+    # selectors were interned into this table above, so its allocator is holding something
+    @test CC.getTotalMemory(selt) > 0
 
     # ---- ObjC family classification: a plain C++ identifier vs a family name ----
     @test CC.getMethodFamily(nullary) == CC.CXObjCMethodFamily_OMF_None

--- a/test/clang/api/Basic/Module.jl
+++ b/test/clang/api/Basic/Module.jl
@@ -44,14 +44,13 @@ using Test
 
     @test CC.getModuleInputBufferName() == "<module-includes>"
 
-    # Availability of a hand-built module is host-decided, and so is the transition a
-    # failing requirement would drive: markUnavailable reads bits a synthetic module
-    # never had a module map to set. Only the shape is asserted.
+    # Neither availability nor the transition a failing requirement would drive is an
+    # answer here: markUnavailable reads bits a synthetic module never had a module map
+    # to set. Only the shape is asserted.
     @test CC.addRequirement(root, "cplusplus", true, lang_opts, target) === nothing
-    # A synthetic module has no module map, so isAvailable reads bits that were never
-    # set and the answer differs per runner (CLAUDE.md records this); only the shape
-    # of it is assertable here.
-    @test CC.isAvailable(root) isa Bool  # shape-only: the host decides this
+    # A synthetic module has no module map, so isAvailable reads bits nothing ever set
+    # (CLAUDE.md records this class); only the shape of it is assertable here.
+    @test CC.isAvailable(root) isa Bool  # shape-only: nothing decides it — reads bits never set on a synthetic module
 
     text = CC.print(root, 0, false)
     @test text isa String

--- a/test/clang/api/Basic/SourceLocation.jl
+++ b/test/clang/api/Basic/SourceLocation.jl
@@ -25,8 +25,15 @@ using Test
     @test CC.isInvalid(ploc) == !CC.isValid(ploc)
     if CC.isValid(ploc)
         @test CC.getFilename(ploc) isa String
-        @test CC.getLine(ploc) isa Integer  # shape-only: the target chooses this value
-        @test CC.getColumn(ploc) isa Integer  # shape-only: the target chooses this value
+        # No target chooses these: the source is one line, so the presumed line is 1 and
+        # the column is where the name is written. They differ, which is the only reason
+        # the two accessors are separable at all -- `isa Integer` held for both.
+        # PresumedLoc is the #line-aware view and no #line is in play, so it has to agree
+        # with the source manager's own spelling numbers for the same location.
+        @test CC.getLine(ploc) == 1
+        @test CC.getColumn(ploc) > 1
+        @test CC.getLine(ploc) == CC.getSpellingLineNumber(sm, loc)
+        @test CC.getColumn(ploc) == CC.getSpellingColumnNumber(sm, loc)
         @test !CC.is_null_handle(CC.getIncludeLoc(ploc))
         pfid = CC.getFileID(ploc)
         @test pfid isa CC.FileID

--- a/test/clang/api/Basic/SourceManager.jl
+++ b/test/clang/api/Basic/SourceManager.jl
@@ -147,7 +147,16 @@ end
     @test CC.getHashValue(fid2) == CC.getHashValue(fid)
     @test CC.getFileOffset(sm, loc) == off
     @test CC.getFileIDSize(sm, fid) > 0
-    @test CC.getNumCreatedFIDsForFileID(sm, fid) isa Integer  # shape-only: the target chooses this value
+    # How many FileIDs this one spawned depends on what the default include path pulls in,
+    # so the count itself is not pinnable -- but the setter makes it observable, which is
+    # what separates a working getter from one answering a constant. `force` is needed
+    # because clang refuses to overwrite a count already set. Restored afterwards so later
+    # assertions see the source manager as they found it.
+    created = Int(CC.getNumCreatedFIDsForFileID(sm, fid))
+    CC.setNumCreatedFIDsForFileID(sm, fid, created + 3, true)
+    @test Int(CC.getNumCreatedFIDsForFileID(sm, fid)) == created + 3
+    CC.setNumCreatedFIDsForFileID(sm, fid, created, true)
+    @test Int(CC.getNumCreatedFIDsForFileID(sm, fid)) == created
     inside, rel = CC.isInFileID(sm, loc, fid)
     @test inside
     @test rel == off
@@ -314,11 +323,14 @@ end
     # ---- SourceManager: state and size queries ----
     @test !(CC.userFilesAreVolatile(sm))
     @test CC.hasLineTable(sm)
-    @test CC.getContentCacheSize(sm) isa Integer  # shape-only: the host decides this
-    @test CC.local_sloc_entry_size(sm) isa Integer  # shape-only: the target chooses this value
+    @test CC.getContentCacheSize(sm) > 0
     @test CC.local_sloc_entry_size(sm) > 0
-    @test CC.loaded_sloc_entry_size(sm) isa Integer  # shape-only: the target chooses this value
-    @test CC.getNextLocalOffset(sm) isa Integer  # shape-only: the target chooses this value
+    # nothing was loaded from an AST file, so every entry in this manager is a local one
+    @test Int(CC.loaded_sloc_entry_size(sm)) == 0
+    # the next offset sits past every local entry, since each one occupies at least a byte
+    # of the address space they are handed out of -- a swallowed counter reads 0 and fails
+    @test CC.getNextLocalOffset(sm) >= CC.local_sloc_entry_size(sm)
+    @test CC.getNextLocalOffset(sm) > 0
 
     # the line table is materialised on demand by getLineTableFilenameID
     fnid = CC.getLineTableFilenameID(sm, "sm-batch-b.h")
@@ -363,9 +375,9 @@ end
     # ---- Module ----
     root = CC.Module_("SmbTopMod"; visibility_id=3)
     @test CC.getVisibilityID(root) == 3
-    # another bit a synthetic module never had a module map to set, so the answer is
-    # the runner's rather than clang's -- only its shape is assertable
-    @test CC.isNamedModuleInterfaceHasInit(root) isa Bool  # shape-only: the host decides this
+    # another bit a synthetic module never had a module map to set, so there is no
+    # answer to read -- only its shape is assertable
+    @test CC.isNamedModuleInterfaceHasInit(root) isa Bool  # shape-only: nothing decides it — never set on a module built without a module map
     @test !(CC.isForBuilding(root, langopts))
     @test CC.getASTFile(root) === nothing
     @test CC.addTopHeaderFilename(root, "smb-top.h") === nothing
@@ -385,14 +397,13 @@ end
     # real module map or requirement list to set. Windows CI observed isAvailable still
     # true after the call while macOS and Linux observed false. Only the shape is
     # asserted; the call itself still exercises the wrapper.
-    # A synthetic module has no module map, so isAvailable reads bits that were never
-    # set and the answer differs per runner (CLAUDE.md records this); only the shape
-    # of it is assertable here.
-    @test CC.isAvailable(root) isa Bool  # shape-only: the host decides this
+    # A synthetic module has no module map, so isAvailable reads bits nothing ever set
+    # (CLAUDE.md records this class); only the shape of it is assertable here.
+    @test CC.isAvailable(root) isa Bool  # shape-only: nothing decides it — reads bits never set on a synthetic module
     @test CC.markUnavailable(root, true) === nothing
     # same synthetic-module caveat: the markUnavailable transition is gated on bits a
     # module built without a module map never had
-    @test CC.isAvailable(root) isa Bool  # shape-only: the host decides this
+    @test CC.isAvailable(root) isa Bool  # shape-only: nothing decides it — reads bits never set on a synthetic module
     CC.dispose(root)
 
     CC.dispose(I)
@@ -420,7 +431,8 @@ end
     entry, invalid = CC.getSLocEntry(sm, mainid)
     @test entry isa CC.SLocEntry
     @test invalid isa Bool
-    @test CC.getOffset(entry) isa Integer  # shape-only: the target chooses this value
+    # every local entry sits below the offset the manager would hand out next
+    @test CC.getOffset(entry) < CC.getNextLocalOffset(sm)
 
     # Which indices hold a file and which a macro expansion is decided by the parse, so the
     # exemplars are found by scanning instead of being hard-coded.
@@ -443,7 +455,7 @@ end
 
     # ---- SrcMgr::FileInfo ----
     fe = CC.getLocalSLocEntry(sm, file_idx)
-    @test CC.getOffset(fe) isa Integer  # shape-only: the target chooses this value
+    @test CC.getOffset(fe) < CC.getNextLocalOffset(sm)
     fi = CC.getFile(fe)
     @test fi isa CC.FileInfo
     @test CC.is_null_handle(CC.getIncludeLoc(fi))
@@ -506,7 +518,7 @@ end
 
     # ---- SourceManager: configuration and memory accounting ----
     @test CC.setOverridenFilesKeepOriginalName(sm, true) === nothing
-    @test CC.getDataStructureSizes(sm) isa Integer  # shape-only: the host decides this
+    @test CC.getDataStructureSizes(sm) > 0
     malloc_bytes, mmap_bytes = CC.getMemoryBufferSizes(sm)
     @test malloc_bytes isa Integer
     @test mmap_bytes isa Integer
@@ -553,7 +565,7 @@ end
     cc = CC.getContentCache(fi)
     @test cc isa CC.ContentCache
     @test CC.isBufferLoaded(cc)
-    @test CC.getSizeBytesMapped(cc) isa Integer  # shape-only: the host decides this
+    @test CC.getSizeBytesMapped(cc) isa Integer  # shape-only: the host decides it — whether a buffer is mmap'd rather than read into malloc'd memory is the loader's choice
     ccdata = CC.getBufferDataIfLoaded(cc)
     @test ccdata === nothing || ccdata isa String
     if CC.isBufferLoaded(cc)

--- a/test/clang/api/Basic/TargetInfo.jl
+++ b/test/clang/api/Basic/TargetInfo.jl
@@ -486,7 +486,7 @@ end
     # from strings that passed validateCpuSupports. On a target with no multiversioning
     # support nothing validates and the loop body simply does not run.
     for f in filter(n -> CC.validateCpuSupports(ti, n), ["sse2", "avx", "neon"])
-        @test CC.multiVersionSortPriority(ti, f) isa Integer  # shape-only: the host decides this
+        @test CC.multiVersionSortPriority(ti, f) isa Integer  # shape-only: the target decides it (CPU feature priorities are per-target tables)
     end
 
     dispose(I)

--- a/test/clang/api/Driver/Driver.jl
+++ b/test/clang/api/Driver/Driver.jl
@@ -24,15 +24,18 @@ end
     drv = CC.Driver(exe, triple, diags)
     @test drv isa CC.Driver
 
-    @test CC.getTargetTriple(drv) isa String  # shape-only: the host decides this
-    @test occursin("x86_64", CC.getTargetTriple(drv))
-    @test CC.getClangProgramPath(drv) isa String  # shape-only: the host decides this
-    @test occursin("clang", CC.getClangProgramPath(drv))
-    @test CC.getInstalledDir(drv) isa String  # shape-only: the host decides this
+    # Nothing here is host-decided: the triple and the executable path are the two the
+    # driver was constructed with, and every derived path follows from them. `isa String`
+    # held equally for an accessor returning a sibling member -- the sysroot and the
+    # resource dir are both strings, and only one of them is empty.
+    @test CC.getTargetTriple(drv) == triple
+    @test CC.getClangProgramPath(drv) == exe
+    @test CC.getInstalledDir(drv) == dirname(exe)
     @test CC.getDir(drv) isa String
-    @test CC.getResourceDir(drv) isa String  # shape-only: the host decides this
-    @test CC.getSysRoot(drv) isa String  # shape-only: the host decides this
-    @test CC.getDyldPrefix(drv) isa String  # shape-only: the host decides this
+    @test occursin("clang", CC.getResourceDir(drv))
+    # no --sysroot and no -isysroot were passed, so these stay at their empty defaults
+    @test isempty(CC.getSysRoot(drv))
+    @test isempty(CC.getDyldPrefix(drv))
 
     old = CC.getCheckInputsExist(drv)
     @test old isa Bool
@@ -57,7 +60,8 @@ end
     # Driver::Mode is a single enum, so at most one predicate can be true.
     @test count(modes) <= 1
 
-    @test CC.getCCCGenericGCCName(drv) isa String  # shape-only: the host decides this
+    # -ccc-gcc-name was not passed, so this is the empty default
+    @test isempty(CC.getCCCGenericGCCName(drv))
     @test !CC.is_null_handle(CC.getDiags(drv))
 
     img = CC.getDefaultImageName(drv)
@@ -125,11 +129,22 @@ end
     diags = CC.DiagnosticsEngine()
     drv = CC.Driver(joinpath("usr", "bin", "clang"), "x86_64-unknown-linux-gnu", diags)
 
-    # isUsingLTO reads the same uninitialized Driver::LTOMode as getLTOMode, but as a
-    # comparison, so it is a valid Bool even on a driver that never processed
-    # arguments -- only its meaning depends on that.
-    @test CC.isUsingLTO(drv) isa Bool  # shape-only: the host decides this
-    @test CC.isUsingLTO(drv, true) isa Bool  # shape-only: the host decides this
+    # isUsingLTO reads Driver::LTOMode, which BuildCompilation is what initialises. Asked
+    # of a driver that never processed arguments it is a comparison against uninitialised
+    # memory: a valid Bool, but not an answer, and pinning it would only make the reading
+    # look trustworthy. Processing arguments first is what gives the two calls a meaning,
+    # and -flto is what separates them -- a predicate stuck at either answer fails here.
+    CC.setCheckInputsExist(drv, false)
+    CC.BuildCompilation(drv, ["clang", "-fsyntax-only", "lto-probe.cpp"])
+    @test CC.isUsingLTO(drv) == false
+
+    lto_drv = CC.Driver(joinpath("usr", "bin", "clang"), "x86_64-unknown-linux-gnu",
+                        CC.DiagnosticsEngine())
+    CC.setCheckInputsExist(lto_drv, false)
+    CC.BuildCompilation(lto_drv, ["clang", "-flto", "-c", "lto-probe.cpp"])
+    @test CC.isUsingLTO(lto_drv) == true
+    # the offload query reads a separate mode that -flto alone does not set
+    @test CC.isUsingLTO(lto_drv, true) == false
 
     # Both create their entry on disk and hand ownership to the caller.
     tmpfile = CC.GetTemporaryPath(drv, "clangcompiler", "tmp")
@@ -180,13 +195,15 @@ end
     src = "clangcompiler-driver-test.cpp"
     comp = CC.BuildCompilation(drv, ["clang", "-fsyntax-only", src])
     @test comp isa CC.Compilation
-    @test CC.isForDiagnostics(comp) isa Bool  # shape-only: the host decides this
-    @test CC.getActiveOffloadKinds(comp) isa Integer  # shape-only: the host decides this
-    @test CC.getSysRoot(comp) isa String  # shape-only: the host decides this
+    # a plain -fsyntax-only compilation: not a diagnostic re-run, no offloading, and the
+    # sysroot it reports is the driver's own
+    @test CC.isForDiagnostics(comp) == false
+    @test Int(CC.getActiveOffloadKinds(comp)) == 0
+    @test CC.getSysRoot(comp) == CC.getSysRoot(drv)
     @test CC.getTempFiles(comp) isa Vector{String}
 
     # setContainsError only ever sets the bit, so this round trip is one-way.
-    @test CC.containsError(comp) isa Bool  # shape-only: the host decides this
+    @test CC.containsError(comp) == false
     CC.setContainsError(comp)
     @test CC.containsError(comp)
 
@@ -196,14 +213,20 @@ end
     tc = CC.getDefaultToolChain(comp)
     @test tc isa CC.ToolChain
     @test occursin("x86_64", CC.getTripleString(tc))
-    @test CC.getArchName(tc) isa String  # shape-only: the host decides this
-    @test CC.getOS(tc) isa String  # shape-only: the host decides this
-    @test CC.isCrossCompiling(tc) isa Bool  # shape-only: the host decides this
+    # both are read out of the triple the driver was pinned to, so they are the two
+    # components of it and not each other
+    @test CC.getArchName(tc) == "x86_64"
+    @test CC.getOS(tc) == "linux"
+    # this compares the pinned target triple against the triple of the machine running the
+    # test, so the answer differs from runner to runner
+    @test CC.isCrossCompiling(tc) isa Bool  # shape-only: the host decides it
     @test CC.getTargetTriple(CC.getDriver(tc)) == CC.getTargetTriple(drv)
 
     # Neither lookup has to find anything; both always come back with a path string.
-    @test CC.GetFilePath(drv, "crt1.o", tc) isa String  # shape-only: the host decides this
-    @test CC.GetProgramPath(drv, "ld", tc) isa String  # shape-only: the host decides this
+    # a miss returns the name it was handed rather than an empty string, so the query is
+    # traceable either way
+    @test occursin("crt1.o", CC.GetFilePath(drv, "crt1.o", tc))
+    @test occursin("ld", CC.GetProgramPath(drv, "ld", tc))
 
     banner = CC.PrintVersion(drv, comp)
     @test banner isa String

--- a/test/clang/api/Frontend/ASTUnit.jl
+++ b/test/clang/api/Frontend/ASTUnit.jl
@@ -35,7 +35,8 @@ using Test
     CC.setASTContext(au, ctx)
     @test CC.getASTContext(au).ptr == ctx.ptr
 
-    @test CC.getOnlyLocalDecls(au) isa Bool  # shape-only: the host decides this
+    # ASTUnit::create leaves this at its default; only the LoadFrom* entry points set it
+    @test CC.getOnlyLocalDecls(au) == false
 
     owns = CC.getOwnsRemappedFileBuffers(au)
     @test owns isa Bool
@@ -44,8 +45,8 @@ using Test
     CC.setOwnsRemappedFileBuffers(au, owns)
 
     # No frontend input and no main file registered, so both names come back empty.
-    @test CC.getMainFileName(au) isa String  # shape-only: the host decides this
-    @test CC.getOriginalSourceFileName(au) isa String  # shape-only: the host decides this
+    @test isempty(CC.getMainFileName(au))
+    @test isempty(CC.getOriginalSourceFileName(au))
 
     # The top-level list starts empty and tracks exactly what addTopLevelDecl appends.
     @test CC.top_level_empty(au) == true
@@ -94,9 +95,10 @@ end
     @test to_preamble.end_loc.ptr == rng.end_loc.ptr
 
     # Neither file ID exists on a unit that has never parsed, so both predicates
-    # short-circuit; only the shape is the library's business here.
-    @test CC.isInMainFileID(au, loc) isa Bool  # shape-only: the host decides this
-    @test CC.isInPreambleFileID(au, loc) isa Bool  # shape-only: the host decides this
+    # short-circuit to false. That agreement is why they cannot be told apart here --
+    # the parsed unit in the load testset is where one is true and the other is not.
+    @test CC.isInMainFileID(au, loc) == false
+    @test CC.isInPreambleFileID(au, loc) == false
     # this unit was built without a main file or a preamble, so both are the invalid
     # location -- the documented answer, and one a shim handing back a stale location fails
     @test CC.isInvalid(CC.getStartOfMainFileID(au))
@@ -154,9 +156,10 @@ end
     inv = CC.CompilerInvocation()
     au = CC.ASTUnit(inv, CC.getDiagnostics(ci))
 
-    # The unsafe-to-free bit is a bit-field with no in-class initializer, so only a value the
-    # test itself wrote is asserted.
-    @test CC.isUnsafeToFree(au) isa Bool  # shape-only: the host decides this
+    # The unsafe-to-free bit is a bit-field with no in-class initializer, so reading it
+    # before anything writes it reads uninitialized memory. Only the values the test
+    # itself wrote are asserted; the initial read is not one, and asserting its shape
+    # would only make an unanswerable question look answered.
     @test CC.setUnsafeToFree(au, true) === nothing
     @test CC.isUnsafeToFree(au) == true
     @test CC.setUnsafeToFree(au, false) === nothing
@@ -169,12 +172,13 @@ end
 
     # C++ hands the top-level name hash back as a mutable reference; round-trip it through
     # the read/write pair the C surface splits it into.
-    @test CC.getCurrentTopLevelHashValue(au) isa Integer  # shape-only: the host decides this
+    # the initial read is the same uninitialized bit-field case as above, so the round
+    # trip starts at the write
     @test CC.setCurrentTopLevelHashValue(au, 0x1234) === nothing
     @test CC.getCurrentTopLevelHashValue(au) == 0x1234
 
     # Nothing has built a preamble and nothing has cached completion results.
-    @test CC.getPreambleCounterForTests(au) isa Integer  # shape-only: the host decides this
+    @test Int(CC.getPreambleCounterForTests(au)) == 0
     @test CC.cached_completion_size(au) == 0
 
     # No parse has run, so the unit captured no diagnostics and the driver split sits at the
@@ -189,8 +193,9 @@ end
     # accessors on the instance that owns it.
     CC.createFrontendTimer(ci)
     @test CC.hasFrontendTimer(ci)
-    @test CC.getFrontendTimerName(ci) isa String  # shape-only: the host decides this
-    @test CC.isFrontendTimerRunning(ci) isa Bool  # shape-only: the host decides this
+    # clang names it, not the host, and creating a timer does not start it
+    @test CC.getFrontendTimerName(ci) == "frontend"
+    @test CC.isFrontendTimerRunning(ci) == false
 
     dispose(I)
 end
@@ -228,6 +233,15 @@ end
         @test CC.isMainFileAST(au) == false
         @test basename(CC.getMainFileName(au)) == "astunit_load.cpp"
         @test basename(CC.getOriginalSourceFileName(au)) == "astunit_load.cpp"
+
+        # A unit that parsed has a main file ID, which is what separates the two region
+        # predicates: on the never-parsed unit both short-circuit to false and a shim
+        # answering either question with the other's result passes. Here they differ --
+        # no preamble was built, so a location in the main file is in one and not the other.
+        main_start = CC.getStartOfMainFileID(au)
+        @test CC.isValid(main_start)
+        @test CC.isInMainFileID(au, main_start) == true
+        @test CC.isInPreambleFileID(au, main_start) == false
 
         # The top-level list is this file's and not another unit's: both declarations the
         # source writes are in it, under the kind names clang gave them.

--- a/test/clang/api/Frontend/CompilerInstance.jl
+++ b/test/clang/api/Frontend/CompilerInstance.jl
@@ -71,8 +71,10 @@ using Test
     hs = CC.getHeaderSearchInfo(pp)
     @test hs isa CC.HeaderSearch
     @test (CC.PrintStats(pp); true)
-    @test CC.isIncrementalProcessingEnabled(pp) isa Bool  # shape-only: the host decides this
-    @test (CC.enableIncrementalProcessing(pp); CC.isIncrementalProcessingEnabled(pp)) isa Bool
+    # the interpreter drives clang incrementally, so this is already on before anything
+    # here touches it, and enabling it again is idempotent rather than a toggle
+    @test CC.isIncrementalProcessingEnabled(pp) == true
+    @test (CC.enableIncrementalProcessing(pp); CC.isIncrementalProcessingEnabled(pp)) == true
 
     # ---- HeaderSearch / HeaderSearchOptions / PreprocessorOptions ----
     @test (CC.PrintStats(hs); true)
@@ -105,25 +107,33 @@ using Test
     # LookupResult construction + unqualified LookupName
     nm = CC.DeclarationName(CC.get_name(ctx, "compute"))
     lr = CC.LookupResult(sema, nm, widget_loc, CC.CXLookupNameKind_LookupOrdinaryName)
-    @test CC.LookupName(sema, lr, scope, true) isa Bool  # shape-only: the host decides this
+    # `compute` is a file-scope function in this translation unit, so an unqualified
+    # ordinary-name lookup finds it. Nothing about that is host-decided.
+    @test CC.LookupName(sema, lr, scope, true) == true
 
     # LookupParsedName on a fresh result + scope spec
     ss_lp = CC.CXXScopeSpec()
     lr2 = CC.LookupResult(sema, nm, widget_loc, CC.CXLookupNameKind_LookupOrdinaryName)
-    @test CC.LookupParsedName(sema, lr2, scope, ss_lp, true, true) isa Bool  # shape-only: the host decides this
+    @test CC.LookupParsedName(sema, lr2, scope, ss_lp, true, true) == true
 
     # ---- LookupResult query surface (Sema/Lookup.jl) on the populated `lr` ----
     @test (CC.resolveKind(lr); true)
-    @test CC.isForRedeclaration(lr) isa Bool  # shape-only: the host decides this
-    @test CC.isTemplateNameLookup(lr) isa Bool  # shape-only: the host decides this
-    @test CC.isAmbiguous(lr) isa Bool
-    @test CC.isSingleResult(lr) isa Bool  # shape-only: the host decides this
-    @test CC.isOverloadedResult(lr) isa Bool  # shape-only: the host decides this
-    @test CC.isUnresolvableResult(lr) isa Bool  # shape-only: the host decides this
-    @test CC.isClassLookup(lr) isa Bool  # shape-only: the host decides this
-    @test CC.isSingleTagDecl(lr) isa Bool  # shape-only: the host decides this
-    @test CC.empty(lr) isa Bool  # shape-only: the host decides this
-    @test CC.getNum(lr) isa Integer  # shape-only: the host decides this
+    # `compute` is a single non-overloaded free function found by ordinary lookup, so
+    # every one of these has an answer the source decides. `isa Bool` held for all of
+    # them at once and so could not tell one predicate from another; these values can.
+    @test CC.isForRedeclaration(lr) == false     # the shim's default is NotForRedeclaration
+    @test CC.isTemplateNameLookup(lr) == false
+    @test CC.isAmbiguous(lr) == false
+    @test CC.isSingleResult(lr) == true
+    @test CC.isOverloadedResult(lr) == false
+    @test CC.isUnresolvableResult(lr) == false
+    @test CC.isClassLookup(lr) == false          # LookupOrdinaryName, not a class member lookup
+    @test CC.isSingleTagDecl(lr) == false        # a function, not a tag
+    @test CC.empty(lr) == false
+    @test Int(CC.getNum(lr)) == 1
+    # and the count agrees with the two predicates derived from it
+    @test CC.empty(lr) == (Int(CC.getNum(lr)) == 0)
+    @test CC.isSingleResult(lr) == (Int(CC.getNum(lr)) == 1)
     @test CC.getResults(lr) isa Vector
     @test !CC.is_null_handle(CC.getRepresentativeDecl(lr))
     @test !CC.is_null_handle(CC.getLookupName(lr))
@@ -148,10 +158,15 @@ using Test
     dss = CC.CXXScopeSpec()
     tail = CC.parse_cxx_scope_spec(I, dss, "NS::Inner")
     @test tail isa AbstractString
-    @test CC.isValid(dss) isa Bool  # shape-only: the host decides this
-    @test CC.isInvalid(dss) isa Bool  # shape-only: the host decides this
-    @test CC.isEmpty(dss) isa Bool  # shape-only: the host decides this
-    @test CC.isNotEmpty(dss) isa Bool  # shape-only: the host decides this
+    # `NS::Inner` names a real nested scope, so the spec parsed and is populated. The two
+    # pairs are complements of each other, which is the part `isa Bool` cannot state: two
+    # predicates wired to the same underlying query satisfy it and fail this.
+    @test CC.isValid(dss) == true
+    @test CC.isInvalid(dss) == false
+    @test CC.isEmpty(dss) == false
+    @test CC.isNotEmpty(dss) == true
+    @test CC.isValid(dss) == !CC.isInvalid(dss)
+    @test CC.isNotEmpty(dss) == !CC.isEmpty(dss)
     @test !CC.is_null_handle(CC.getScopeRep(dss))
     bloc = CC.getBeginLoc(dss)
     eloc = CC.getEndLoc(dss)
@@ -160,19 +175,22 @@ using Test
     @test (CC.setBeginLoc(dss, bloc); true)
     @test (CC.setEndLoc(dss, eloc); true)
     sr = CC.SourceRange(bloc, eloc)
-    @test CC.getRange(dss, sr) isa CC.SourceRange  # shape-only: the host decides this
+    @test CC.getRange(dss, sr) isa CC.SourceRange  # shape-only: varies with the scope spec the parse left behind
     @test (CC.setRange(dss, sr); true)
     @test (CC.clear(dss); true)
     dispose(dss)
 
     # ---- Parser: read-only queries (Parse/Parser.jl) ----
-    @test CC.getLangOpts(parser) isa CC.LangOptions  # shape-only: the host decides this
-    @test CC.getTargetInfo(parser) isa CC.TargetInfo  # shape-only: the host decides this
-    @test CC.getPreprocessor(parser) isa CC.Preprocessor  # shape-only: the host decides this
-    @test CC.getActions(parser) isa CC.Sema  # shape-only: the host decides this
+    # the parser borrows these from the CompilerInstance rather than owning copies, so
+    # each is the very same object -- an accessor reading a neighbouring member returns a
+    # perfectly well-typed carrier and fails only on identity
+    @test CC.getLangOpts(parser).ptr == CC.getLangOpts(sema).ptr
+    @test CC.getTargetInfo(parser).ptr == CC.getTarget(ci).ptr
+    @test CC.getPreprocessor(parser).ptr == CC.getPreprocessor(ci).ptr
+    @test CC.getActions(parser).ptr == CC.getSema(ci).ptr
     tok = CC.getCurToken(parser)
     @test tok isa CC.Token
-    @test CC.NextToken(parser) isa CC.Token  # shape-only: the host decides this
+    @test CC.NextToken(parser) isa CC.Token  # shape-only: varies with where the incremental parser is resting
 
     # pure helper functions over the parser context enums
     @test CC.getDeclSpecContextFromDeclaratorContext(CC.CXDeclaratorContext_Member) isa CC.CXDeclSpecContext
@@ -182,11 +200,12 @@ using Test
     @test CC.shouldEnterContext(CC.CXDeclSpecContext_DSC_normal) isa Bool
 
     # ---- Token query surface (Lex/Token.jl) ----
-    @test CC.getLocation(tok) isa CC.SourceLocation  # shape-only: the host decides this
+    # a token the parser is actually resting on was written somewhere
+    @test CC.isValid(CC.getLocation(tok))
     @test CC.getAnnotationEndLoc(tok) isa CC.SourceLocation
     @test CC.getAnnotationRange(tok) isa CC.SourceRange
     @test CC.getName(tok) isa String
-    @test CC.getAnnotationValue(tok) isa CC.AnnotationValue  # shape-only: the host decides this
+    @test CC.getAnnotationValue(tok) isa CC.AnnotationValue  # shape-only: varies with the token kind the parser is resting on
     @test CC.is_eof(tok) isa Bool
     @test CC.is_annot_repl_input_end(tok) isa Bool
     @test CC.is_identifier(tok) isa Bool
@@ -206,7 +225,6 @@ using Test
     CC.EnterSourceFile(pp, ident_fid)
     CC.is_annot_repl_input_end(tok) && CC.ConsumeAnyToken(parser)
     @test CC.is_identifier(tok)
-    @test CC.getIdentifierInfo(tok) isa CC.IdentifierInfo  # shape-only: the host decides this
     @test CC.getName(CC.getIdentifierInfo(tok)) == "Widget"
     while !CC.is_annot_repl_input_end(tok)
         CC.ConsumeAnyToken(parser)
@@ -216,7 +234,7 @@ using Test
     dispose(ident_fid)
 
     # QualType annotation read off a token (Parse/Parser.jl)
-    @test CC.getTypeAnnotation(tok) isa CC.QualType  # shape-only: the host decides this
+    @test CC.getTypeAnnotation(tok) isa CC.QualType  # shape-only: varies with the token kind the parser is resting on
 
     # ---- Preprocessor dump helpers (need a token / a location) ----
     @test (CC.DumpToken(pp, tok); true)
@@ -229,11 +247,12 @@ using Test
     @test CC.TryAnnotateOptionalCXXScopeToken(parser, false) isa Bool
     @test CC.TryAnnotateOptionalCXXScopeToken(parser, CC.CXDeclSpecContext_DSC_class) isa Bool
     @test CC.TryAnnotateOptionalCXXScopeToken(parser, CC.CXDeclaratorContext_Member) isa Bool
-    @test CC.TryAnnotateTypeOrScopeToken(parser) isa Bool  # shape-only: the host decides this
+    @test CC.TryAnnotateTypeOrScopeToken(parser) isa Bool  # shape-only: varies with where the incremental parser is resting
     ss_af = CC.CXXScopeSpec()
-    @test CC.TryAnnotateTypeOrScopeTokenAfterScopeSpec(parser, ss_af) isa Bool  # shape-only: the host decides this
+    @test CC.TryAnnotateTypeOrScopeTokenAfterScopeSpec(parser, ss_af) isa Bool  # shape-only: varies with where the incremental parser is resting
     dispose(ss_af)
-    @test CC.ConsumeAnyToken(parser) isa CC.SourceLocation  # shape-only: the host decides this
+    # the location it hands back is the token it consumed, which was a real one
+    @test CC.isValid(CC.ConsumeAnyToken(parser))
 
     dispose(f)
     dispose(I)
@@ -245,7 +264,9 @@ end
     # CompilerInstance: no plugins are requested, so loading them is a no-op
     ci = CC.get_instance(I)
     @test (CC.LoadRequestedPlugins(ci); true)
-    @test CC.hasFrontendTimer(ci) isa Bool  # shape-only: the host decides this
+    # -ftime-report was not passed, so there is no timer until one is made -- the half of
+    # the round trip that says the assertion below is the create doing something
+    @test CC.hasFrontendTimer(ci) == false
     CC.createFrontendTimer(ci)
     @test CC.hasFrontendTimer(ci)
 
@@ -257,7 +278,9 @@ end
     # instance already answers and the setter round-trips.
     ci = CC.CompilerInstance()
 
-    @test CC.buildingModule(ci) isa Bool  # shape-only: the host decides this
+    # ModuleLoader's constructor sets it false, so the initial answer is a value and not
+    # an uninitialised read -- which is what makes the setter round trip below meaningful
+    @test CC.buildingModule(ci) == false
     @test !CC.buildingModule(ci)
     @test CC.setBuildingModule(ci, true) === nothing
     @test CC.buildingModule(ci)

--- a/test/clang/api/Frontend/FrontendAction.jl
+++ b/test/clang/api/Frontend/FrontendAction.jl
@@ -23,7 +23,9 @@ using Test
     @test CC.usesPreprocessorOnly(act) == false
     @test CC.hasPCHSupport(act) == true
     @test CC.hasASTFileSupport(act) == true
-    @test CC.hasIRSupport(act) isa Bool  # shape-only: the host decides this
+    # `act` is an LLVMOnlyAction, i.e. a CodeGenAction, which is the class that overrides
+    # this to true -- the comment above says as much, so the class decides it, not the host
+    @test CC.hasIRSupport(act) == true
     @test CC.hasCodeCompletionSupport(act) == false
     @test CC.getTranslationUnitKind(act) == CC.LibClangEx.CXTranslationUnitKind_TU_Complete
 
@@ -60,7 +62,6 @@ using Test
     inv = CC.CompilerInvocation()
     @test CC.resetNonModularOptions(inv) === nothing
     @test CC.clearImplicitModuleBuildOptions(inv) === nothing
-    @test CC.getModuleHash(inv) isa String  # shape-only: the host decides this
     @test !isempty(CC.getModuleHash(inv))
     dispose(inv)
 end

--- a/test/clang/api/Lex/Preprocessor.jl
+++ b/test/clang/api/Lex/Preprocessor.jl
@@ -23,12 +23,12 @@ end
     pp = CC.getPreprocessor(get_instance(I))
 
     @test !CC.is_null_handle(CC.getPreprocessorOpts(pp))
-    @test CC.getNumDirectives(pp) isa Integer  # shape-only: the target chooses this value
+    # this interpreter was handed `-include cstddef`, so directives were seen
+    @test CC.getNumDirectives(pp) > 0
     @test CC.isParsingIfOrElifDirective(pp) == false
     @test !(CC.isPreprocessedOutput(pp))
     @test CC.isInPrimaryFile(pp)
     @test !(CC.SawDateOrTime(pp))
-    @test CC.getTotalMemory(pp) isa Integer  # shape-only: the target chooses this value
     @test CC.getTotalMemory(pp) > 0
     @test CC.isInNamedModule(pp) == false
 

--- a/test/clang/api/Sema/Lookup.jl
+++ b/test/clang/api/Sema/Lookup.jl
@@ -26,7 +26,8 @@ using Test
     @test !(CC.isFunctionScope(sc))
     @test !(CC.isClassScope(sc))
     @test !(CC.containedInPrototypeScope(sc))
-    @test CC.getFunctionPrototypeDepth(sc) isa Integer  # shape-only: the target chooses this value
+    # not a prototype scope, as the line above asserts, so the depth is the outermost
+    @test Int(CC.getFunctionPrototypeDepth(sc)) == 0
     @test CC.is_null_handle(CC.getContinueParent(sc))
     @test CC.is_null_handle(CC.getBreakParent(sc))
     @test CC.is_null_handle(CC.getBlockParent(sc))
@@ -55,7 +56,11 @@ using Test
     @test !CC.isSuppressingAccessDiagnostics(r)
     @test !CC.isSuppressingAmbiguousDiagnostics(r)
     @test CC.is_null_handle(CC.getBaseObjectType(r))
-    @test CC.getContextRange(r) isa CC.SourceRange  # shape-only
+    # nothing has set a lookup context on `r` yet, so the context range is still the
+    # invalid default -- the same unset state the null base object type reports, and a
+    # value an accessor reading the name location instead would not produce
+    @test !CC.isValid((CC.getContextRange(r)).begin_loc)
+    @test !CC.isValid((CC.getContextRange(r)).end_loc)
 
     found = CC.LookupQualifiedName(sema, r, tu)
     @test found
@@ -221,11 +226,11 @@ end
     # has no mangling parent, which is the only value this test can pin down on every host.
     ms_parent = CC.getMSLastManglingParent(sc)
     @test ms_parent isa CC.Scope
-    @test CC.getMSCurManglingNumber(sc) isa Integer  # shape-only: the host decides this
+    @test CC.getMSCurManglingNumber(sc) isa Integer  # shape-only: varies with what the incremental parser has already mangled into this scope
     if ms_parent.ptr == C_NULL
         @test CC.getMSLastManglingNumber(sc) == 1
     else
-        @test CC.getMSLastManglingNumber(sc) isa Integer  # shape-only: the host decides this
+        @test CC.getMSLastManglingNumber(sc) isa Integer  # shape-only: varies with what the incremental parser has already mangled into this scope
     end
 
     # Contains compares scope depths, so a scope never contains itself and a parent always
@@ -410,7 +415,9 @@ end
     @test CC.getAlignMode(aligned) == CC.CXAlignPackInfo_Natural
     @test CC.IsXLStack(aligned)
     @test !CC.IsPackSet(aligned)
-    @test CC.getPackNumber(aligned) isa Integer  # shape-only: the target chooses this value
+    # IsPackSet is false above, so the slot still holds AlignPackInfo::UninitPackVal --
+    # clang's "no pack number recorded" sentinel, not a pack number of zero
+    @test Int(CC.getPackNumber(aligned)) == 255
     dispose(aligned)
 
     # Sema::DefaultedFunctionKind over a record declaring four special members and one
@@ -431,6 +438,7 @@ end
     @test !isempty(methods)
 
     any_special = false
+    diag_idx = Int[]
     for m in methods
         dfk = CC.getDefaultedFunctionKind(sema, m)
         @test dfk isa CC.DefaultedFunctionKind
@@ -443,11 +451,16 @@ end
         @test CC.isComparison(dfk) == (comparison != CC.CXDefaultedComparisonKind_None)
         # getSpecialMember is the already-bound spelling of the same query
         @test special == CC.getSpecialMember(sema, m)
-        @test CC.getDiagnosticIndex(dfk) isa Integer  # shape-only: the target chooses this value
+        push!(diag_idx, Int(CC.getDiagnosticIndex(dfk)))
         any_special |= CC.isSpecialMember(dfk)
         dispose(dfk)
     end
     @test any_special
+    # the diagnostic index identifies which defaulted-function arm a diagnostic is about,
+    # so the four special members this record declares carry four different ones. Its
+    # numeric values are clang's, but their distinctness is the source's.
+    @test length(diag_idx) >= 4
+    @test length(unique(diag_idx)) == length(diag_idx)
 
     # LookupResult: the redeclaration flavour round-trips, and the result renders
     loc = CC.get_main_file_begin_loc(sm)
@@ -561,6 +574,16 @@ end
     i0 = CC.getNextFunctionPrototypeIndex(proto)
     @test i0 isa Integer
     @test CC.getNextFunctionPrototypeIndex(proto) == i0 + 1
+
+    # The depth counts the prototype scopes enclosing a scope, itself included, so the
+    # three scopes here sit at three different values. Without a nested one the suite only
+    # ever sees 0, and an accessor pinned at the outermost value is indistinguishable from
+    # a working one.
+    proto2 = CC.Scope(proto, UInt32(CC.CXScopeFlags_FunctionPrototypeScope) | decl_flags, diag)
+    @test Int(CC.getFunctionPrototypeDepth(s)) == 0
+    @test Int(CC.getFunctionPrototypeDepth(proto)) == 1
+    @test Int(CC.getFunctionPrototypeDepth(proto2)) == 2
+    dispose(proto2)
 
     # --- A template parameter scope refuses setEntity but accepts setLookupEntity ---
     tps = CC.Scope(nothing, UInt32(CC.CXScopeFlags_TemplateParamScope) | decl_flags, diag)

--- a/test/clang/api/Sema/Sema.jl
+++ b/test/clang/api/Sema/Sema.jl
@@ -2982,7 +2982,10 @@ end
     # target-decided: what counts as a valid section specifier follows the object
     # file format (Mach-O vs ELF vs COFF), so only the shape of the answer holds across CI runners
     @test CC.isValidSectionSpecifier(sema, "__TEXT,__text") isa Bool  # shape-only: host target section format rules decide this
-    @test CC.isValidSectionSpecifier(sema, "not a section specifier") isa Bool  # shape-only: host target section format rules decide this
+    # Only Mach-O imposes a grammar on the name -- it wants `segment,section`, so a string
+    # with spaces is rejected there and accepted under ELF and COFF, which take almost any
+    # name. There is no spelling that is invalid on all three.
+    @test CC.isValidSectionSpecifier(sema, "not a section specifier") isa Bool  # shape-only: the target decides it (object file format)
     cuda_name = CC.getCudaConfigureFuncName(sema)
     @test cuda_name isa String
     @test !isempty(cuda_name)

--- a/test/clang/api/Sema/TemplateDeduction.jl
+++ b/test/clang/api/Sema/TemplateDeduction.jl
@@ -34,9 +34,9 @@ using Test
     @test info.ptr != C_NULL
     @test !CC.is_null_handle(CC.getLocation(info))
     @test CC.getDeducedDepth(info) == 0
-    @test CC.getNumExplicitArgs(info) isa Integer  # shape-only: the target chooses this value
+    @test Int(CC.getNumExplicitArgs(info)) == 0
     @test !(CC.hasSFINAEDiagnostic(info))
-    @test CC.getCallArgIndex(info) isa Integer  # shape-only: the target chooses this value
+    @test Int(CC.getCallArgIndex(info)) == 0
     @test CC.takeCanonical(info).ptr == C_NULL
 
     # --- matching a class template partial specialization against an argument list ---

--- a/test/clang/pinned_target.jl
+++ b/test/clang/pinned_target.jl
@@ -127,7 +127,9 @@ end
 
         @test CC.getRegisterWidth(ti) == 64
         @test CC.isTLSSupported(ti)
-        @test CC.isVLASupported(ti) isa Bool  # shape-only: the target chooses this value
+        # this whole testset is pinned to x86_64-unknown-linux-gnu, which supports VLAs --
+   # the pin is exactly what turns a target-decided answer into an assertable one
+        @test CC.isVLASupported(ti) == true
 
         dispose(I)
     end

--- a/test/lint.jl
+++ b/test/lint.jl
@@ -282,7 +282,8 @@ const LINT_FILE = @__FILE__
         out = read(ignorestatus(`$(Base.julia_cmd()) $script`), String)
         unmarked = [m.captures[1] for m in eachmatch(r"^    (\S+:\d+)"m, out)]
         isempty(unmarked) ||
-            @error "assertions that cannot fail and are not marked `# shape-only`" unmarked
+            @error "assertions that cannot fail, either unmarked or marked `# shape-only` " *
+                   "without naming one of the three admitted reasons" unmarked
         @test isempty(unmarked)
     end
 

--- a/test/tautologies.jl
+++ b/test/tautologies.jl
@@ -39,8 +39,8 @@ const TESTS = joinpath(ROOT, "test")
 # a precondition to state rather than an answer to record. Sites in the second class were all
 # labelled with the first before this existed, which read as though someone had checked.
 #
-# What this can and cannot do: it checks that a reason was *stated* and names one of the three
-# categories. It cannot check that the claim is TRUE -- `getLine` marked "the target chooses
+# What this can and cannot do: it checks that a reason was *stated* and names one of the
+# categories above. It cannot check that the claim is TRUE -- `getLine` marked "the target chooses
 # this value" satisfies every pattern below and is still false, because a line number is
 # decided by the source. Only reading the site catches that. Without the check, though, a
 # marker with no reason at all reads exactly like one that was thought about.
@@ -290,7 +290,7 @@ function main()
     end
     if !isempty(bare)
         nf = report(bare)
-        println("`$MARKER` markers whose reason is missing or names none of the three admitted")
+        println("`$MARKER` markers whose reason is missing or names none of the $(length(REASONS)) admitted")
         println("categories: $(length(bare)) across $nf files\n")
         println("The marker is an exemption from the rule above, so it states the ground it was")
         println("granted on. One of these must be recognisable in the text after it:")

--- a/test/tautologies.jl
+++ b/test/tautologies.jl
@@ -31,6 +31,78 @@ const MARKER = "# shape-only"
 const API = joinpath(ROOT, "src", "clang")
 const TESTS = joinpath(ROOT, "test")
 
+# The marker is an exemption, so it carries the reason it was granted under. CLAUDE.md admits
+# four and no others; these match them by keyword, leaving the prose free.
+#
+# The fourth is not a weaker version of the first. "The host decides it" says a real machine
+# chose a real value; "nothing decides it" says the read was of memory nobody wrote, which is
+# a precondition to state rather than an answer to record. Sites in the second class were all
+# labelled with the first before this existed, which read as though someone had checked.
+#
+# What this can and cannot do: it checks that a reason was *stated* and names one of the three
+# categories. It cannot check that the claim is TRUE -- `getLine` marked "the target chooses
+# this value" satisfies every pattern below and is still false, because a line number is
+# decided by the source. Only reading the site catches that. Without the check, though, a
+# marker with no reason at all reads exactly like one that was thought about.
+const REASONS = ["the host decides it" =>
+                     r"\bhost\b|\bsysroot\b|\brunner\b|\bworking directory\b|\bexecutable path\b"i,
+                 "the target decides it" =>
+                     r"\btarget\b|\bABI\b|\btriple\b|\bmangl|\blayout\b|\balign|\bendian|\bplatform\b"i,
+                 "it varies across the objects the test walks" =>
+                     r"\bvar(?:y|ies|ying)\b|\bwalk|\bdiffers\b|\bnode to node\b"i,
+                 "nothing decides it -- the read is uninitialised" =>
+                     r"\buninitiali[sz]ed\b|\bnever set\b|\bnever initiali[sz]ed\b|\bno in-class initiali[sz]er\b"i]
+
+"""
+    split_comment(line) -> (code, comment)
+
+Split `line` at its trailing comment, with `comment` keeping its `#`.
+
+The assertion pattern is anchored at end-of-code, so the comment has to come off before the
+match rather than being tolerated inside it. Anchoring at end-of-*line* instead is what made
+this check vacuous: every marked site ends in `# shape-only`, so none of them matched the
+pattern, the marker test below was unreachable, and any trailing comment whatsoever -- not
+just the marker -- exempted an assertion from the ratchet.
+
+The scan tracks string and character literals so a `#` inside one is not mistaken for the
+start of a comment.
+"""
+function split_comment(line)
+    instr = inchar = escaped = false
+    for (i, c) in pairs(line)
+        if escaped
+            escaped = false
+        elseif c == '\\'
+            escaped = true
+        elseif instr
+            c == '"' && (instr = false)
+        elseif inchar
+            c == '\'' && (inchar = false)
+        elseif c == '"'
+            instr = true
+        elseif c == '\''
+            inchar = true
+        elseif c == '#'
+            return (line[1:prevind(line, i)], line[i:end])
+        end
+    end
+    return (line, "")
+end
+
+"""
+    reason_of(comment) -> String
+
+The prose following the marker, or `""` when the marker carries none.
+
+Split on the marker rather than matched as a whole so that a site writing `# shape-only`
+with no colon is reported as missing a reason instead of silently not matching.
+"""
+function reason_of(comment)
+    i = findfirst(MARKER, comment)
+    i === nothing && return ""
+    return strip(lstrip(comment[(last(i) + 1):end], [':', ' ', '\t', '-', '—']))
+end
+
 "A ccall's declared return type, e.g. `clang_Foo_bar` => `:Cuint`."
 function ccall_returns(binding_file)
     out = Dict{String,Symbol}()
@@ -92,6 +164,44 @@ function wrapper_returns(dir, ccalls)
     return out
 end
 
+"The assertion this script hunts for, matched against a line with its comment already removed."
+const ASSERTION = r"@test\s+(?:CC\.|ClangCompiler\.)?(\w+)\(.*\)\s+isa\s+(?:CC\.|ClangCompiler\.)?([\w{}]+)\s*$"
+
+"""
+    self_check()
+
+Fail loudly if the line mechanics stop recognising the shapes they are supposed to.
+
+This exists because the detector went vacuous once without anyone noticing: `ASSERTION` was
+matched against the whole line, so a site ending in `# shape-only` -- which is every marked
+site, and any commented assertion besides -- did not match at all. The marker test below it
+was unreachable, every marker was decorative, and the script reported a clean tree. A clean
+tree and a broken detector print the same sentence, which is what makes this worth asserting.
+"""
+function self_check()
+    probe = "    @test CC.getNumBases(rd) isa Integer"
+    for (suffix, want) in ("" => "", "  # prose" => "# prose",
+                           "  # shape-only" => "# shape-only",
+                           "  # shape-only: the host decides this" =>
+                               "# shape-only: the host decides this")
+        code, comment = split_comment(probe * suffix)
+        comment == want || error("split_comment lost the comment on `$probe$suffix`: got `$comment`")
+        match(ASSERTION, strip(code)) === nothing &&
+            error("the assertion pattern no longer matches `$probe$suffix`")
+    end
+    # a `#` inside a string literal does not start a comment
+    _, c = split_comment("""    @test CC.getName(d) == "a#b" """)
+    isempty(c) || error("split_comment read a `#` inside a string as a comment: `$c`")
+    # every admitted reason is recognised by its own pattern, and prose naming none is not
+    for (name, _) in REASONS
+        any(p -> occursin(last(p), name), REASONS) ||
+            error("the admitted reason `$name` matches none of the patterns")
+    end
+    any(p -> occursin(last(p), "because it seemed fine"), REASONS) &&
+        error("the reason patterns accept prose that names no category")
+    return nothing
+end
+
 "Whether a result of shape `shape` is always an instance of `asserted`."
 function always_isa(shape, asserted)
     shape === :unknown && return false
@@ -109,55 +219,87 @@ function always_isa(shape, asserted)
 end
 
 function main()
+    self_check()
     ccalls = ccall_returns(joinpath(ROOT, "lib", "18", "LibClangEx.jl"))
     rets = wrapper_returns(API, ccalls)
     isempty(ccalls) && (println("no ccalls parsed — is lib/18/LibClangEx.jl present?"); return 2)
 
     hits = Tuple{String,Int,String,String}[]
+    bare = Tuple{String,Int,String,String}[]
     for (root, _, files) in walkdir(TESTS), f in files
         endswith(f, ".jl") || continue
         occursin(".cov", f) && continue
         path = joinpath(root, f)
         for (n, line) in enumerate(eachline(path))
-            m = match(r"@test\s+(?:CC\.|ClangCompiler\.)?(\w+)\(.*\)\s+isa\s+(?:CC\.|ClangCompiler\.)?([\w{}]+)\s*$",
-                      strip(line))
+            code, comment = split_comment(line)
+            m = match(ASSERTION, strip(code))
             m === nothing && continue
             fname, asserted = m.captures[1], Symbol(m.captures[2])
             shapes = get(rets, fname, nothing)
             shapes === nothing && continue
             # sound only when every method of the name agrees
             all(s -> always_isa(s, asserted), shapes) || continue
+            # forward slashes always: this output is compared against a checked-in
+            # baseline, and Windows would otherwise report every path as a new file
+            rel = replace(relpath(path, ROOT), '\\' => '/')
             # An accepted exception carries the marker at the site, with its reason beside
             # it. Recording these in a separate baseline file instead put the count three
             # directories from the code, drifted whenever a file was cleaned up, and made
             # two branches conflict over a generated artifact.
-            occursin(MARKER, line) && continue
-            # forward slashes always: this output is compared against a checked-in
-            # baseline, and Windows would otherwise report every path as a new file
-            push!(hits, (replace(relpath(path, ROOT), '\\' => '/'), n, fname, strip(line)))
+            if occursin(MARKER, comment)
+                # The marker alone used to end the check here, which made the reason a
+                # comment nobody read: a third of the exemptions carried none at all.
+                r = reason_of(comment)
+                any(p -> occursin(last(p), r), REASONS) && continue
+                push!(bare, (rel, n, fname, strip(line)))
+                continue
+            end
+            push!(hits, (rel, n, fname, strip(line)))
         end
     end
 
-    if isempty(hits)
-        println("every statically-true `isa` assertion carries the `$MARKER` marker")
+    if isempty(hits) && isempty(bare)
+        println("every statically-true `isa` assertion carries the `$MARKER` marker, with a reason")
         return 0
     end
-    byfile = Dict{String,Vector{Tuple{Int,String,String}}}()
-    for (p, n, fn, code) in hits
-        push!(get!(byfile, p, Tuple{Int,String,String}[]), (n, fn, code))
-    end
-    println("`@test ... isa ...` assertions that cannot fail: $(length(hits)) across $(length(byfile)) files\n")
-    for p in sort!(collect(keys(byfile)); by=k -> -length(byfile[k]))
-        println("--- $p  ($(length(byfile[p])))")
-        for (n, fn, code) in byfile[p]
-            println("    $p:$n  $code")
+
+    # Group by file and print, densest file first. The four-space indent is load-bearing:
+    # test/lint.jl scrapes `path:line` out of it to decide whether CI fails.
+    function report(rows)
+        byfile = Dict{String,Vector{Tuple{Int,String,String}}}()
+        for (p, n, fn, code) in rows
+            push!(get!(byfile, p, Tuple{Int,String,String}[]), (n, fn, code))
         end
+        for p in sort!(collect(keys(byfile)); by=k -> -length(byfile[k]))
+            println("--- $p  ($(length(byfile[p])))")
+            for (n, fn, code) in byfile[p]
+                println("    $p:$n  $code")
+            end
+        end
+        return length(byfile)
     end
-    println("\nEach restates the wrapper's own return expression. Assert what Clang decided")
-    println("instead: a value, a round trip, or a relationship the shim could get wrong.")
-    println("If the value genuinely is not assertable -- the host decides it, it varies across")
-    println("the objects the test walks, or it is an integer the target chooses -- mark the")
-    println("line `$MARKER` and say which of those it is.")
+
+    if !isempty(hits)
+        nf = report(hits)
+        println("`@test ... isa ...` assertions that cannot fail: $(length(hits)) across $nf files\n")
+        println("Each restates the wrapper's own return expression. Assert what Clang decided")
+        println("instead: a value, a round trip, or a relationship the shim could get wrong.")
+        println("If the value genuinely is not assertable -- the host decides it, it varies across")
+        println("the objects the test walks, or it is an integer the target chooses -- mark the")
+        println("line `$MARKER` and say which of those it is.\n")
+    end
+    if !isempty(bare)
+        nf = report(bare)
+        println("`$MARKER` markers whose reason is missing or names none of the three admitted")
+        println("categories: $(length(bare)) across $nf files\n")
+        println("The marker is an exemption from the rule above, so it states the ground it was")
+        println("granted on. One of these must be recognisable in the text after it:")
+        for (name, _) in REASONS
+            println("  - $name")
+        end
+        println("\nIf none of them is true of the site, the value is assertable and the marker")
+        println("is the wrong fix -- assert what Clang decided instead.")
+    end
     return 1
 end
 


### PR DESCRIPTION
Three of this repo's audit tools reported healthy numbers while unable to detect the thing they measure. Fixing them exposed 124 assertions that could not fail; this converts them.

| tool | reported | actually |
|---|---|---|
| `test/tautologies.jl` | a clean tree | its pattern matched **nothing** carrying a comment |
| `mutants.jl` score | 100% | described only the files its mutants touched |
| `mutants.jl` score | 93.8% | was scoring a suite that was **already red** |

## 1. The detector matched nothing

`tautologies.jl` anchored its pattern with `\s*$` right after the asserted type, matching the whole line. **Any** trailing comment stopped a line matching — and every `# shape-only` site ends in one, so no marked line ever reached the marker test below it:

```julia
occursin(MARKER, line) && continue   # unreachable
```

152 markers were decoration, the ratchet was open to any tautology willing to carry a comment, and ten had already gone through.

`self_check()` now runs first and asserts the four shapes: bare, commented, marker-without-reason, marker-with-reason.

Markers must now name an admitted reason. Before, 32 of 152 named none and 27 blamed the target for values the source decides (`getLine`, `getColumn`, `getCommandID`, `getParamIndex`). The check verifies a category was *named*, never that the claim is true, and says so. The rule also gained a fourth reason — "nothing decides it" — because CLAUDE.md described that case with nowhere to put it, so every site in it had to claim the host.

## 2. The score measured its own scope

Nine mutants, all in AST core, all running only `AST_CORE` files. It fell about thirty points every time the catalogue reached new ground:

| region added | survived | score |
|---|---|---|
| `CompilerInstance`, `Driver` | 6 of 7 | 100% → 62.5% |
| `SourceManager`, `ASTUnit`, `Comment`, `IdentifierTable` | 7 of 8 | 100% → 70.8% |
| `CFG`, `Lex`, `Sema` | 3 of 8 | → 90.6% |

## 3. The score was measured against a red tree

`run_mutant` called a mutant caught whenever `Test Failed` appeared, without checking the files passed unmutated. One broken assertion marked **every** mutant over that file set as caught.

Not hypothetical: a wrong expected value I introduced (`getPackNumber` on an unset alignment slot is clang's `UninitPackVal` sentinel, 255, not 0) reported two genuine survivors as caught in the same run that introduced it. Each file set now runs unmutated first; a red one ends the run with exit 3. Verified by breaking an assertion on purpose.

## What the markers were hiding

Almost every converted site had the missing assertion written beside it as prose:

| was | now |
|---|---|
| `getQualifierRange(ule) isa SourceRange  # ll_oo is unqualified` | `!isValid(...begin_loc)` |
| `getCond(frs) isa Expr_  # implicit __begin != __end` | opcode `== BO_NE` |
| `getModifier(ops[1]) isa Char  # '\0' when none` | `== '\0'` |

**Unpinnable values with pinnable relationships.** A comment command's ID indexes clang's `CommandTraits` table and moves with the release — but a name and its ID must identify each other, asserted as a biconditional over every pair. `getNumCreatedFIDsForFileID` depends on the include path, so a *relative* round trip through its setter makes it observable.

**Three sites needed the state built, not the assertion rewritten.** The construction-context index was 0 everywhere until a call took its object in second position and a lambda took a second capture; the prototype depth was 0 until a scope was nested in the existing one. While only slot 0 exists, an accessor ignoring its subject is indistinguishable from a working one.

**Four uninitialized reads, not pinned.** `isUsingLTO`, `isUnsafeToFree`, `getCurrentTopLevelHashValue` and the synthetic-`Module` bits read memory nobody wrote while their markers blamed the host. Two lose their opening assertion (a setter round trip follows). `isUsingLTO` got the better fix — `BuildCompilation` initializes the field, so the site asserts a real partition.

**The Driver tests were never host-dependent.** They pin `x86_64-unknown-linux-gnu` and pass an explicit executable path, so every derived value follows from the test's own inputs. "The host decides this" was stamped across all 18 sites regardless.

## Results

- **Markers 152 → 28.** The two boilerplate strings covering 105 of the original 111 are gone; what remains names a specific host path, target ABI, parser position or uninitialized read.
- **Catalogue 9 → 32 mutants**, 30 caught, 2 blocked, 0 unexpected survivors.
- Green on macOS, Linux and Windows.

Every converted value was probed against real state before being written down. That caught three wrong guesses of mine — `getCXXBindTemporaryExpr`'s taxonomy, the FID count, and `getPackNumber`. A fourth escaped locally and was caught by CI: `isValidSectionSpecifier` on a string with spaces is invalid only under Mach-O, since ELF and COFF accept almost any name. That site keeps its marker, with the reason recorded so the next reader does not repeat the experiment.

## Two blocked survivors → #48, #50

Neither is killable by a better assertion; both are missing wrappers. `getMainFileName` and `getOriginalSourceFileName` agree in every reachable state, diverging only after `ASTUnit::LoadFromASTFile`. `getCallArgIndex` is written only by the deduce-from-call-arguments path, which no wrapped overload reaches.

A blocked mutant **still counts against the score** — an exemption that improved the number would be a way of not seeing the gap — but no longer reddens the exit, so a red run means something *new* survived. And the script fails if a blocked mutant *starts* being caught, since the note is stale then. Both directions verified.

Remaining catalogue coverage is tracked in #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
